### PR TITLE
feature: implemented genre in books

### DIFF
--- a/config/genres.js
+++ b/config/genres.js
@@ -1,0 +1,15 @@
+// Centralized list of genres we support across the app.
+module.exports = [
+    'Fiction',
+    'Non-Fiction',
+    'Fantasy',
+    'Science Fiction',
+    'Mystery',
+    'Biography',
+    'History',
+    'Romance',
+    'Young Adult',
+    'Self-Help',
+    'Poetry',
+    'Other'
+]

--- a/config/passport.js
+++ b/config/passport.js
@@ -4,6 +4,7 @@ const mongoose = require('mongoose')
 const User = require('../models/user')
 
 module.exports = function (passport) {
+
     passport.use(new LocalStrategy({ usernameField: 'email' }, async (email, password, done) => {
         try {
             const user = await User.findOne({ email: email.toLowerCase() });
@@ -24,7 +25,9 @@ module.exports = function (passport) {
             return done(err)
             console.error(err)
         }
-    })),
+    }))
+
+    if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
     passport.use(new GoogleStrategy({
         clientID: process.env.GOOGLE_CLIENT_ID,
         clientSecret: process.env.GOOGLE_CLIENT_SECRET,
@@ -56,6 +59,8 @@ module.exports = function (passport) {
             console.error(err)
         }
     }))
+    }
+    
 
     // Persist user data (after successful authentication) into session
     passport.serializeUser(async (user, done) => {

--- a/controller/auth.js
+++ b/controller/auth.js
@@ -117,8 +117,14 @@ module.exports = {
                 return res.redirect('../signup');
             }
             await user.save();
-            await req.logIn(user);
-            res.redirect('/dashboard')
+            req.logIn(user, (err) => {
+                if (err) {
+                    console.error('Signup login error:', err)
+                    req.flash('errors', { msg: 'There was a problem signing you in automatically. Please log in manually.' })
+                    return res.redirect('/login')
+                }
+                res.redirect('/dashboard')
+            })
         } catch (err) {
             console.error(err)
         }

--- a/controller/books.js
+++ b/controller/books.js
@@ -64,6 +64,7 @@ module.exports = {
             isbn: req.body.isbn,
             title: req.body.title,
             description: req.body.description,
+            genre: req.body.genre || 'Other',
             publishDate: new Date(req.body.publishDate),
             pageCount: req.body.pageCount,
             author: req.body.author
@@ -90,6 +91,7 @@ module.exports = {
             book.publishDate = new Date(req.body.publishDate)
             book.pageCount = req.body.pageCount
             book.description = req.body.description
+            book.genre = req.body.genre || 'Other'
             // Checks to see if cover exist and not an empty string
             if(req.body.cover != null && req.body.cover !== ''){
                 saveCover(book, req.body.cover)

--- a/controller/dashboard.js
+++ b/controller/dashboard.js
@@ -1,14 +1,33 @@
 const Author = require('../models/author')
 const Book = require('../models/book')
 const User = require('../models/user')
+const genres = require('../config/genres')
 
 module.exports = {
     getIndex: async (req, res) => {
         try {
-            const books = await Book.find().populate('author');
-            console.log(books)
-            const booksCount = await Book.countDocuments({}).exec()
-            const authorsCount = await Author.countDocuments({}).exec()
+            const { genre: selectedGenre, genreSort } = req.query
+
+            const bookFilter = {}
+            if (selectedGenre) {
+                bookFilter.genre = selectedGenre
+            }
+
+            let sortOrder = { createdAt: -1 }
+            if (genreSort === 'asc') {
+                sortOrder = { genre: 1, title: 1 }
+            } else if (genreSort === 'desc') {
+                sortOrder = { genre: -1, title: 1 }
+            }
+
+            const bookQuery = Book.find(bookFilter).sort(sortOrder).populate('author')
+
+            const [books, booksCount, authorsCount, distinctGenres] = await Promise.all([
+                bookQuery.exec(),
+                Book.countDocuments({}).exec(),
+                Author.countDocuments({}).exec(),
+                Book.distinct('genre')
+            ])
 
             if (!req.isAuthenticated()) {
                 return res.redirect('/login');
@@ -25,6 +44,11 @@ module.exports = {
                 'Deleted "Old Book"',
             ];
 
+            const genreOptions = Array.from(new Set([
+                ...genres,
+                ...distinctGenres.filter(Boolean)
+            ])).sort((a, b) => a.localeCompare(b))
+
             res.render('dashboard', { 
                 title: 'Dashboard', 
                 layout: 'layouts/dashboard', 
@@ -33,7 +57,10 @@ module.exports = {
                 books: books,
                 booksCount: booksCount,
                 authorsCount: authorsCount,
-                activities
+                activities,
+                genres: genreOptions,
+                selectedGenre,
+                genreSort
             })
         } catch (err) {
             console.error(err)

--- a/models/book.js
+++ b/models/book.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose')
+const genres = require('../config/genres')
 
 const bookSchema = new mongoose.Schema({
     isbn: {
@@ -11,6 +12,12 @@ const bookSchema = new mongoose.Schema({
     },
     description: {
         type: String
+    },
+    genre: {
+        type: String,
+        enum: genres,
+        default: 'Other',
+        trim: true
     },
     publishDate: {
         type: Date,

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1,641 +1,22848 @@
+@charset "UTF-8";
+/*!
+ * Bootstrap  v5.3.7 (https://getbootstrap.com/)
+ * Copyright 2011-2025 The Bootstrap Authors
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
+ */
+:root,
+[data-bs-theme=light] {
+  --bs-blue: #0d6efd;
+  --bs-indigo: #6610f2;
+  --bs-purple: #6f42c1;
+  --bs-pink: #d63384;
+  --bs-red: #d0181e;
+  --bs-orange: #fd7e14;
+  --bs-yellow: #ffc107;
+  --bs-green: #198754;
+  --bs-teal: #20c997;
+  --bs-cyan: #0dcaf0;
+  --bs-black: #000000;
+  --bs-white: #ffffff;
+  --bs-gray: #6c757d;
+  --bs-gray-dark: #343a40;
+  --bs-gray-100: #f8f9fa;
+  --bs-gray-200: #e9ecef;
+  --bs-gray-300: #dee2e6;
+  --bs-gray-400: #ced4da;
+  --bs-gray-500: #adb5bd;
+  --bs-gray-600: #6c757d;
+  --bs-gray-700: #495057;
+  --bs-gray-800: #343a40;
+  --bs-gray-900: #212529;
+  --bs-primary: #0A1929;
+  --bs-secondary: #143252;
+  --bs-success: #198754;
+  --bs-info: #0dcaf0;
+  --bs-warning: #ffc107;
+  --bs-danger: #d0181e;
+  --bs-light: #f8f9fa;
+  --bs-dark: #212529;
+  --bs-primary-rgb: 10, 25, 41;
+  --bs-secondary-rgb: 20, 50, 82;
+  --bs-success-rgb: 25, 135, 84;
+  --bs-info-rgb: 13, 202, 240;
+  --bs-warning-rgb: 255, 193, 7;
+  --bs-danger-rgb: 208, 24, 30;
+  --bs-light-rgb: 248, 249, 250;
+  --bs-dark-rgb: 33, 37, 41;
+  --bs-primary-text-emphasis: rgb(4, 10, 16.4);
+  --bs-secondary-text-emphasis: rgb(8, 20, 32.8);
+  --bs-success-text-emphasis: rgb(10, 54, 33.6);
+  --bs-info-text-emphasis: rgb(5.2, 80.8, 96);
+  --bs-warning-text-emphasis: rgb(102, 77.2, 2.8);
+  --bs-danger-text-emphasis: rgb(83.2, 9.6, 12);
+  --bs-light-text-emphasis: #495057;
+  --bs-dark-text-emphasis: #495057;
+  --bs-primary-bg-subtle: rgb(206, 209, 212.2);
+  --bs-secondary-bg-subtle: rgb(208, 214, 220.4);
+  --bs-success-bg-subtle: rgb(209, 231, 220.8);
+  --bs-info-bg-subtle: rgb(206.6, 244.4, 252);
+  --bs-warning-bg-subtle: rgb(255, 242.6, 205.4);
+  --bs-danger-bg-subtle: rgb(245.6, 208.8, 210);
+  --bs-light-bg-subtle: rgb(251.5, 252, 252.5);
+  --bs-dark-bg-subtle: #ced4da;
+  --bs-primary-border-subtle: rgb(157, 163, 169.4);
+  --bs-secondary-border-subtle: rgb(161, 173, 185.8);
+  --bs-success-border-subtle: rgb(163, 207, 186.6);
+  --bs-info-border-subtle: rgb(158.2, 233.8, 249);
+  --bs-warning-border-subtle: rgb(255, 230.2, 155.8);
+  --bs-danger-border-subtle: rgb(236.2, 162.6, 165);
+  --bs-light-border-subtle: #e9ecef;
+  --bs-dark-border-subtle: #adb5bd;
+  --bs-white-rgb: 255, 255, 255;
+  --bs-black-rgb: 0, 0, 0;
+  --bs-font-sans-serif: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --bs-font-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --bs-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0));
+  --bs-body-font-family: var(--bs-font-sans-serif);
+  --bs-body-font-size: 1rem;
+  --bs-body-font-weight: 400;
+  --bs-body-line-height: 1.5;
+  --bs-body-color: #212529;
+  --bs-body-color-rgb: 33, 37, 41;
+  --bs-body-bg: #ffffff;
+  --bs-body-bg-rgb: 255, 255, 255;
+  --bs-emphasis-color: #000000;
+  --bs-emphasis-color-rgb: 0, 0, 0;
+  --bs-secondary-color: rgba(33, 37, 41, 0.75);
+  --bs-secondary-color-rgb: 33, 37, 41;
+  --bs-secondary-bg: #e9ecef;
+  --bs-secondary-bg-rgb: 233, 236, 239;
+  --bs-tertiary-color: rgba(33, 37, 41, 0.5);
+  --bs-tertiary-color-rgb: 33, 37, 41;
+  --bs-tertiary-bg: #f8f9fa;
+  --bs-tertiary-bg-rgb: 248, 249, 250;
+  --bs-heading-color: inherit;
+  --bs-link-color: #0A1929;
+  --bs-link-color-rgb: 10, 25, 41;
+  --bs-link-decoration: underline;
+  --bs-link-hover-color: rgb(8, 20, 32.8);
+  --bs-link-hover-color-rgb: 8, 20, 33;
+  --bs-code-color: #d63384;
+  --bs-highlight-color: #212529;
+  --bs-highlight-bg: rgb(255, 242.6, 205.4);
+  --bs-border-width: 1px;
+  --bs-border-style: solid;
+  --bs-border-color: #dee2e6;
+  --bs-border-color-translucent: rgba(0, 0, 0, 0.175);
+  --bs-border-radius: 0.375rem;
+  --bs-border-radius-sm: 0.25rem;
+  --bs-border-radius-lg: 0.5rem;
+  --bs-border-radius-xl: 1rem;
+  --bs-border-radius-xxl: 2rem;
+  --bs-border-radius-2xl: var(--bs-border-radius-xxl);
+  --bs-border-radius-pill: 50rem;
+  --bs-box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+  --bs-box-shadow-sm: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+  --bs-box-shadow-lg: 0 1rem 3rem rgba(0, 0, 0, 0.175);
+  --bs-box-shadow-inset: inset 0 1px 2px rgba(0, 0, 0, 0.075);
+  --bs-focus-ring-width: 0.25rem;
+  --bs-focus-ring-opacity: 0.25;
+  --bs-focus-ring-color: rgba(10, 25, 41, 0.25);
+  --bs-form-valid-color: #198754;
+  --bs-form-valid-border-color: #198754;
+  --bs-form-invalid-color: #d0181e;
+  --bs-form-invalid-border-color: #d0181e;
+}
 
+[data-bs-theme=dark] {
+  color-scheme: dark;
+  --bs-body-color: #dee2e6;
+  --bs-body-color-rgb: 222, 226, 230;
+  --bs-body-bg: #212529;
+  --bs-body-bg-rgb: 33, 37, 41;
+  --bs-emphasis-color: #ffffff;
+  --bs-emphasis-color-rgb: 255, 255, 255;
+  --bs-secondary-color: rgba(222, 226, 230, 0.75);
+  --bs-secondary-color-rgb: 222, 226, 230;
+  --bs-secondary-bg: #343a40;
+  --bs-secondary-bg-rgb: 52, 58, 64;
+  --bs-tertiary-color: rgba(222, 226, 230, 0.5);
+  --bs-tertiary-color-rgb: 222, 226, 230;
+  --bs-tertiary-bg: rgb(42.5, 47.5, 52.5);
+  --bs-tertiary-bg-rgb: 43, 48, 53;
+  --bs-primary-text-emphasis: rgb(108, 117, 126.6);
+  --bs-secondary-text-emphasis: rgb(114, 132, 151.2);
+  --bs-success-text-emphasis: rgb(117, 183, 152.4);
+  --bs-info-text-emphasis: rgb(109.8, 223.2, 246);
+  --bs-warning-text-emphasis: rgb(255, 217.8, 106.2);
+  --bs-danger-text-emphasis: rgb(226.8, 116.4, 120);
+  --bs-light-text-emphasis: #f8f9fa;
+  --bs-dark-text-emphasis: #dee2e6;
+  --bs-primary-bg-subtle: rgb(2, 5, 8.2);
+  --bs-secondary-bg-subtle: rgb(4, 10, 16.4);
+  --bs-success-bg-subtle: rgb(5, 27, 16.8);
+  --bs-info-bg-subtle: rgb(2.6, 40.4, 48);
+  --bs-warning-bg-subtle: rgb(51, 38.6, 1.4);
+  --bs-danger-bg-subtle: rgb(41.6, 4.8, 6);
+  --bs-light-bg-subtle: #343a40;
+  --bs-dark-bg-subtle: #1a1d20;
+  --bs-primary-border-subtle: rgb(6, 15, 24.6);
+  --bs-secondary-border-subtle: rgb(12, 30, 49.2);
+  --bs-success-border-subtle: rgb(15, 81, 50.4);
+  --bs-info-border-subtle: rgb(7.8, 121.2, 144);
+  --bs-warning-border-subtle: rgb(153, 115.8, 4.2);
+  --bs-danger-border-subtle: rgb(124.8, 14.4, 18);
+  --bs-light-border-subtle: #495057;
+  --bs-dark-border-subtle: #343a40;
+  --bs-heading-color: inherit;
+  --bs-link-color: rgb(108, 117, 126.6);
+  --bs-link-hover-color: rgb(137.4, 144.6, 152.28);
+  --bs-link-color-rgb: 108, 117, 127;
+  --bs-link-hover-color-rgb: 137, 145, 152;
+  --bs-code-color: rgb(230.4, 132.6, 181.2);
+  --bs-highlight-color: #dee2e6;
+  --bs-highlight-bg: rgb(102, 77.2, 2.8);
+  --bs-border-color: #495057;
+  --bs-border-color-translucent: rgba(255, 255, 255, 0.15);
+  --bs-form-valid-color: rgb(117, 183, 152.4);
+  --bs-form-valid-border-color: rgb(117, 183, 152.4);
+  --bs-form-invalid-color: rgb(226.8, 116.4, 120);
+  --bs-form-invalid-border-color: rgb(226.8, 116.4, 120);
+}
 
-/* Custom CSS for the project */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
 
+@media (prefers-reduced-motion: no-preference) {
+  :root {
+    scroll-behavior: smooth;
+  }
+}
+
+body {
+  margin: 0;
+  font-family: var(--bs-body-font-family);
+  font-size: var(--bs-body-font-size);
+  font-weight: var(--bs-body-font-weight);
+  line-height: var(--bs-body-line-height);
+  color: var(--bs-body-color);
+  text-align: var(--bs-body-text-align);
+  background-color: var(--bs-body-bg);
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+
+hr {
+  margin: 1rem 0;
+  color: inherit;
+  border: 0;
+  border-top: var(--bs-border-width) solid;
+  opacity: 0.25;
+}
+
+h6, .h6, h5, .h5, h4, .h4, h3, .h3, h2, .h2, h1, .h1 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+  line-height: 1.2;
+  color: var(--bs-heading-color);
+}
+
+h1, .h1 {
+  font-size: calc(1.375rem + 1.5vw);
+}
+@media (min-width: 1200px) {
+  h1, .h1 {
+    font-size: 2.5rem;
+  }
+}
+
+h2, .h2 {
+  font-size: calc(1.325rem + 0.9vw);
+}
+@media (min-width: 1200px) {
+  h2, .h2 {
+    font-size: 2rem;
+  }
+}
+
+h3, .h3 {
+  font-size: calc(1.3rem + 0.6vw);
+}
+@media (min-width: 1200px) {
+  h3, .h3 {
+    font-size: 1.75rem;
+  }
+}
+
+h4, .h4 {
+  font-size: calc(1.275rem + 0.3vw);
+}
+@media (min-width: 1200px) {
+  h4, .h4 {
+    font-size: 1.5rem;
+  }
+}
+
+h5, .h5 {
+  font-size: 1.25rem;
+}
+
+h6, .h6 {
+  font-size: 1rem;
+}
+
+p {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+abbr[title] {
+  text-decoration: underline dotted;
+  cursor: help;
+  text-decoration-skip-ink: none;
+}
+
+address {
+  margin-bottom: 1rem;
+  font-style: normal;
+  line-height: inherit;
+}
+
+ol,
+ul {
+  padding-left: 2rem;
+}
+
+ol,
+ul,
+dl {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+ol ol,
+ul ul,
+ol ul,
+ul ol {
+  margin-bottom: 0;
+}
+
+dt {
+  font-weight: 700;
+}
+
+dd {
+  margin-bottom: 0.5rem;
+  margin-left: 0;
+}
+
+blockquote {
+  margin: 0 0 1rem;
+}
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+small, .small {
+  font-size: 0.875em;
+}
+
+mark, .mark {
+  padding: 0.1875em;
+  color: var(--bs-highlight-color);
+  background-color: var(--bs-highlight-bg);
+}
+
+sub,
+sup {
+  position: relative;
+  font-size: 0.75em;
+  line-height: 0;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+a {
+  color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 1));
+  text-decoration: underline;
+}
+a:hover {
+  --bs-link-color-rgb: var(--bs-link-hover-color-rgb);
+}
+
+a:not([href]):not([class]), a:not([href]):not([class]):hover {
+  color: inherit;
+  text-decoration: none;
+}
+
+pre,
+code,
+kbd,
+samp {
+  font-family: var(--bs-font-monospace);
+  font-size: 1em;
+}
+
+pre {
+  display: block;
+  margin-top: 0;
+  margin-bottom: 1rem;
+  overflow: auto;
+  font-size: 0.875em;
+}
+pre code {
+  font-size: inherit;
+  color: inherit;
+  word-break: normal;
+}
+
+code {
+  font-size: 0.875em;
+  color: var(--bs-code-color);
+  word-wrap: break-word;
+}
+a > code {
+  color: inherit;
+}
+
+kbd {
+  padding: 0.1875rem 0.375rem;
+  font-size: 0.875em;
+  color: var(--bs-body-bg);
+  background-color: var(--bs-body-color);
+  border-radius: 0.25rem;
+}
+kbd kbd {
+  padding: 0;
+  font-size: 1em;
+}
+
+figure {
+  margin: 0 0 1rem;
+}
+
+img,
+svg {
+  vertical-align: middle;
+}
+
+table {
+  caption-side: bottom;
+  border-collapse: collapse;
+}
+
+caption {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  color: var(--bs-secondary-color);
+  text-align: left;
+}
+
+th {
+  text-align: inherit;
+  text-align: -webkit-match-parent;
+}
+
+thead,
+tbody,
+tfoot,
+tr,
+td,
+th {
+  border-color: inherit;
+  border-style: solid;
+  border-width: 0;
+}
+
+label {
+  display: inline-block;
+}
+
+button {
+  border-radius: 0;
+}
+
+button:focus:not(:focus-visible) {
+  outline: 0;
+}
+
+input,
+button,
+select,
+optgroup,
+textarea {
+  margin: 0;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+button,
+select {
+  text-transform: none;
+}
+
+[role=button] {
+  cursor: pointer;
+}
+
+select {
+  word-wrap: normal;
+}
+select:disabled {
+  opacity: 1;
+}
+
+[list]:not([type=date]):not([type=datetime-local]):not([type=month]):not([type=week]):not([type=time])::-webkit-calendar-picker-indicator {
+  display: none !important;
+}
+
+button,
+[type=button],
+[type=reset],
+[type=submit] {
+  -webkit-appearance: button;
+}
+button:not(:disabled),
+[type=button]:not(:disabled),
+[type=reset]:not(:disabled),
+[type=submit]:not(:disabled) {
+  cursor: pointer;
+}
+
+::-moz-focus-inner {
+  padding: 0;
+  border-style: none;
+}
+
+textarea {
+  resize: vertical;
+}
+
+fieldset {
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
+legend {
+  float: left;
+  width: 100%;
+  padding: 0;
+  margin-bottom: 0.5rem;
+  line-height: inherit;
+  font-size: calc(1.275rem + 0.3vw);
+}
+@media (min-width: 1200px) {
+  legend {
+    font-size: 1.5rem;
+  }
+}
+legend + * {
+  clear: left;
+}
+
+::-webkit-datetime-edit-fields-wrapper,
+::-webkit-datetime-edit-text,
+::-webkit-datetime-edit-minute,
+::-webkit-datetime-edit-hour-field,
+::-webkit-datetime-edit-day-field,
+::-webkit-datetime-edit-month-field,
+::-webkit-datetime-edit-year-field {
+  padding: 0;
+}
+
+::-webkit-inner-spin-button {
+  height: auto;
+}
+
+[type=search] {
+  -webkit-appearance: textfield;
+  outline-offset: -2px;
+}
+
+/* rtl:raw:
+[type="tel"],
+[type="url"],
+[type="email"],
+[type="number"] {
+  direction: ltr;
+}
+*/
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+::file-selector-button {
+  font: inherit;
+  -webkit-appearance: button;
+}
+
+output {
+  display: inline-block;
+}
+
+iframe {
+  border: 0;
+}
+
+summary {
+  display: list-item;
+  cursor: pointer;
+}
+
+progress {
+  vertical-align: baseline;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+.lead {
+  font-size: 1.25rem;
+  font-weight: 300;
+}
+
+.display-1 {
+  font-weight: 300;
+  line-height: 1.2;
+  font-size: calc(1.625rem + 4.5vw);
+}
+@media (min-width: 1200px) {
+  .display-1 {
+    font-size: 5rem;
+  }
+}
+
+.display-2 {
+  font-weight: 300;
+  line-height: 1.2;
+  font-size: calc(1.575rem + 3.9vw);
+}
+@media (min-width: 1200px) {
+  .display-2 {
+    font-size: 4.5rem;
+  }
+}
+
+.display-3 {
+  font-weight: 300;
+  line-height: 1.2;
+  font-size: calc(1.525rem + 3.3vw);
+}
+@media (min-width: 1200px) {
+  .display-3 {
+    font-size: 4rem;
+  }
+}
+
+.display-4 {
+  font-weight: 300;
+  line-height: 1.2;
+  font-size: calc(1.475rem + 2.7vw);
+}
+@media (min-width: 1200px) {
+  .display-4 {
+    font-size: 3.5rem;
+  }
+}
+
+.display-5 {
+  font-weight: 300;
+  line-height: 1.2;
+  font-size: calc(1.425rem + 2.1vw);
+}
+@media (min-width: 1200px) {
+  .display-5 {
+    font-size: 3rem;
+  }
+}
+
+.display-6 {
+  font-weight: 300;
+  line-height: 1.2;
+  font-size: calc(1.375rem + 1.5vw);
+}
+@media (min-width: 1200px) {
+  .display-6 {
+    font-size: 2.5rem;
+  }
+}
+
+.list-unstyled {
+  padding-left: 0;
+  list-style: none;
+}
+
+.list-inline {
+  padding-left: 0;
+  list-style: none;
+}
+
+.list-inline-item {
+  display: inline-block;
+}
+.list-inline-item:not(:last-child) {
+  margin-right: 0.5rem;
+}
+
+.initialism {
+  font-size: 0.875em;
+  text-transform: uppercase;
+}
+
+.blockquote {
+  margin-bottom: 1rem;
+  font-size: 1.25rem;
+}
+.blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.blockquote-footer {
+  margin-top: -1rem;
+  margin-bottom: 1rem;
+  font-size: 0.875em;
+  color: #6c757d;
+}
+.blockquote-footer::before {
+  content: "— ";
+}
+
+.img-fluid {
+  max-width: 100%;
+  height: auto;
+}
+
+.img-thumbnail {
+  padding: 0.25rem;
+  background-color: var(--bs-body-bg);
+  border: var(--bs-border-width) solid var(--bs-border-color);
+  border-radius: var(--bs-border-radius);
+  max-width: 100%;
+  height: auto;
+}
+
+.figure {
+  display: inline-block;
+}
+
+.figure-img {
+  margin-bottom: 0.5rem;
+  line-height: 1;
+}
+
+.figure-caption {
+  font-size: 0.875em;
+  color: var(--bs-secondary-color);
+}
+
+.container,
+.container-fluid,
+.container-xxl,
+.container-xl,
+.container-lg,
+.container-md,
+.container-sm {
+  --bs-gutter-x: 1.5rem;
+  --bs-gutter-y: 0;
+  width: 100%;
+  padding-right: calc(var(--bs-gutter-x) * 0.5);
+  padding-left: calc(var(--bs-gutter-x) * 0.5);
+  margin-right: auto;
+  margin-left: auto;
+}
+
+@media (min-width: 576px) {
+  .container-sm, .container {
+    max-width: 540px;
+  }
+}
+@media (min-width: 768px) {
+  .container-md, .container-sm, .container {
+    max-width: 720px;
+  }
+}
+@media (min-width: 992px) {
+  .container-lg, .container-md, .container-sm, .container {
+    max-width: 960px;
+  }
+}
+@media (min-width: 1200px) {
+  .container-xl, .container-lg, .container-md, .container-sm, .container {
+    max-width: 1140px;
+  }
+}
+@media (min-width: 1400px) {
+  .container-xxl, .container-xl, .container-lg, .container-md, .container-sm, .container {
+    max-width: 1320px;
+  }
+}
 :root {
-    --primary: #0A1929;
-    --secondary: #143252;
+  --bs-breakpoint-xs: 0;
+  --bs-breakpoint-sm: 576px;
+  --bs-breakpoint-md: 768px;
+  --bs-breakpoint-lg: 992px;
+  --bs-breakpoint-xl: 1200px;
+  --bs-breakpoint-xxl: 1400px;
+}
 
-    /* White and Gray Colors */
-    --white:    #ffffff;
-    --gray-100: #f8f9fa;
-    --gray-300: #dee2e6;
-    --gray-500: #adb5bd;
-    --gray-900: #212529;
-    --black: #000000;
+.row {
+  --bs-gutter-x: 1.5rem;
+  --bs-gutter-y: 0;
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: calc(-1 * var(--bs-gutter-y));
+  margin-right: calc(-0.5 * var(--bs-gutter-x));
+  margin-left: calc(-0.5 * var(--bs-gutter-x));
+}
+.row > * {
+  flex-shrink: 0;
+  width: 100%;
+  max-width: 100%;
+  padding-right: calc(var(--bs-gutter-x) * 0.5);
+  padding-left: calc(var(--bs-gutter-x) * 0.5);
+  margin-top: var(--bs-gutter-y);
+}
+
+.col {
+  flex: 1 0 0;
+}
+
+.row-cols-auto > * {
+  flex: 0 0 auto;
+  width: auto;
+}
+
+.row-cols-1 > * {
+  flex: 0 0 auto;
+  width: 100%;
+}
+
+.row-cols-2 > * {
+  flex: 0 0 auto;
+  width: 50%;
+}
+
+.row-cols-3 > * {
+  flex: 0 0 auto;
+  width: 33.33333333%;
+}
+
+.row-cols-4 > * {
+  flex: 0 0 auto;
+  width: 25%;
+}
+
+.row-cols-5 > * {
+  flex: 0 0 auto;
+  width: 20%;
+}
+
+.row-cols-6 > * {
+  flex: 0 0 auto;
+  width: 16.66666667%;
+}
+
+.col-auto {
+  flex: 0 0 auto;
+  width: auto;
+}
+
+.col-1 {
+  flex: 0 0 auto;
+  width: 8.33333333%;
+}
+
+.col-2 {
+  flex: 0 0 auto;
+  width: 16.66666667%;
+}
+
+.col-3 {
+  flex: 0 0 auto;
+  width: 25%;
+}
+
+.col-4 {
+  flex: 0 0 auto;
+  width: 33.33333333%;
+}
+
+.col-5 {
+  flex: 0 0 auto;
+  width: 41.66666667%;
+}
+
+.col-6 {
+  flex: 0 0 auto;
+  width: 50%;
+}
+
+.col-7 {
+  flex: 0 0 auto;
+  width: 58.33333333%;
+}
+
+.col-8 {
+  flex: 0 0 auto;
+  width: 66.66666667%;
+}
+
+.col-9 {
+  flex: 0 0 auto;
+  width: 75%;
+}
+
+.col-10 {
+  flex: 0 0 auto;
+  width: 83.33333333%;
+}
+
+.col-11 {
+  flex: 0 0 auto;
+  width: 91.66666667%;
+}
+
+.col-12 {
+  flex: 0 0 auto;
+  width: 100%;
+}
+
+.offset-1 {
+  margin-left: 8.33333333%;
+}
+
+.offset-2 {
+  margin-left: 16.66666667%;
+}
+
+.offset-3 {
+  margin-left: 25%;
+}
+
+.offset-4 {
+  margin-left: 33.33333333%;
+}
+
+.offset-5 {
+  margin-left: 41.66666667%;
+}
+
+.offset-6 {
+  margin-left: 50%;
+}
+
+.offset-7 {
+  margin-left: 58.33333333%;
+}
+
+.offset-8 {
+  margin-left: 66.66666667%;
+}
+
+.offset-9 {
+  margin-left: 75%;
+}
+
+.offset-10 {
+  margin-left: 83.33333333%;
+}
+
+.offset-11 {
+  margin-left: 91.66666667%;
+}
+
+.g-0,
+.gx-0 {
+  --bs-gutter-x: 0;
+}
+
+.g-0,
+.gy-0 {
+  --bs-gutter-y: 0;
+}
+
+.g-1,
+.gx-1 {
+  --bs-gutter-x: 0.25rem;
+}
+
+.g-1,
+.gy-1 {
+  --bs-gutter-y: 0.25rem;
+}
+
+.g-2,
+.gx-2 {
+  --bs-gutter-x: 0.5rem;
+}
+
+.g-2,
+.gy-2 {
+  --bs-gutter-y: 0.5rem;
+}
+
+.g-3,
+.gx-3 {
+  --bs-gutter-x: 1rem;
+}
+
+.g-3,
+.gy-3 {
+  --bs-gutter-y: 1rem;
+}
+
+.g-4,
+.gx-4 {
+  --bs-gutter-x: 1.5rem;
+}
+
+.g-4,
+.gy-4 {
+  --bs-gutter-y: 1.5rem;
+}
+
+.g-5,
+.gx-5 {
+  --bs-gutter-x: 3rem;
+}
+
+.g-5,
+.gy-5 {
+  --bs-gutter-y: 3rem;
+}
+
+@media (min-width: 576px) {
+  .col-sm {
+    flex: 1 0 0;
+  }
+  .row-cols-sm-auto > * {
+    flex: 0 0 auto;
+    width: auto;
+  }
+  .row-cols-sm-1 > * {
+    flex: 0 0 auto;
+    width: 100%;
+  }
+  .row-cols-sm-2 > * {
+    flex: 0 0 auto;
+    width: 50%;
+  }
+  .row-cols-sm-3 > * {
+    flex: 0 0 auto;
+    width: 33.33333333%;
+  }
+  .row-cols-sm-4 > * {
+    flex: 0 0 auto;
+    width: 25%;
+  }
+  .row-cols-sm-5 > * {
+    flex: 0 0 auto;
+    width: 20%;
+  }
+  .row-cols-sm-6 > * {
+    flex: 0 0 auto;
+    width: 16.66666667%;
+  }
+  .col-sm-auto {
+    flex: 0 0 auto;
+    width: auto;
+  }
+  .col-sm-1 {
+    flex: 0 0 auto;
+    width: 8.33333333%;
+  }
+  .col-sm-2 {
+    flex: 0 0 auto;
+    width: 16.66666667%;
+  }
+  .col-sm-3 {
+    flex: 0 0 auto;
+    width: 25%;
+  }
+  .col-sm-4 {
+    flex: 0 0 auto;
+    width: 33.33333333%;
+  }
+  .col-sm-5 {
+    flex: 0 0 auto;
+    width: 41.66666667%;
+  }
+  .col-sm-6 {
+    flex: 0 0 auto;
+    width: 50%;
+  }
+  .col-sm-7 {
+    flex: 0 0 auto;
+    width: 58.33333333%;
+  }
+  .col-sm-8 {
+    flex: 0 0 auto;
+    width: 66.66666667%;
+  }
+  .col-sm-9 {
+    flex: 0 0 auto;
+    width: 75%;
+  }
+  .col-sm-10 {
+    flex: 0 0 auto;
+    width: 83.33333333%;
+  }
+  .col-sm-11 {
+    flex: 0 0 auto;
+    width: 91.66666667%;
+  }
+  .col-sm-12 {
+    flex: 0 0 auto;
+    width: 100%;
+  }
+  .offset-sm-0 {
+    margin-left: 0;
+  }
+  .offset-sm-1 {
+    margin-left: 8.33333333%;
+  }
+  .offset-sm-2 {
+    margin-left: 16.66666667%;
+  }
+  .offset-sm-3 {
+    margin-left: 25%;
+  }
+  .offset-sm-4 {
+    margin-left: 33.33333333%;
+  }
+  .offset-sm-5 {
+    margin-left: 41.66666667%;
+  }
+  .offset-sm-6 {
+    margin-left: 50%;
+  }
+  .offset-sm-7 {
+    margin-left: 58.33333333%;
+  }
+  .offset-sm-8 {
+    margin-left: 66.66666667%;
+  }
+  .offset-sm-9 {
+    margin-left: 75%;
+  }
+  .offset-sm-10 {
+    margin-left: 83.33333333%;
+  }
+  .offset-sm-11 {
+    margin-left: 91.66666667%;
+  }
+  .g-sm-0,
+  .gx-sm-0 {
+    --bs-gutter-x: 0;
+  }
+  .g-sm-0,
+  .gy-sm-0 {
+    --bs-gutter-y: 0;
+  }
+  .g-sm-1,
+  .gx-sm-1 {
+    --bs-gutter-x: 0.25rem;
+  }
+  .g-sm-1,
+  .gy-sm-1 {
+    --bs-gutter-y: 0.25rem;
+  }
+  .g-sm-2,
+  .gx-sm-2 {
+    --bs-gutter-x: 0.5rem;
+  }
+  .g-sm-2,
+  .gy-sm-2 {
+    --bs-gutter-y: 0.5rem;
+  }
+  .g-sm-3,
+  .gx-sm-3 {
+    --bs-gutter-x: 1rem;
+  }
+  .g-sm-3,
+  .gy-sm-3 {
+    --bs-gutter-y: 1rem;
+  }
+  .g-sm-4,
+  .gx-sm-4 {
+    --bs-gutter-x: 1.5rem;
+  }
+  .g-sm-4,
+  .gy-sm-4 {
+    --bs-gutter-y: 1.5rem;
+  }
+  .g-sm-5,
+  .gx-sm-5 {
+    --bs-gutter-x: 3rem;
+  }
+  .g-sm-5,
+  .gy-sm-5 {
+    --bs-gutter-y: 3rem;
+  }
+}
+@media (min-width: 768px) {
+  .col-md {
+    flex: 1 0 0;
+  }
+  .row-cols-md-auto > * {
+    flex: 0 0 auto;
+    width: auto;
+  }
+  .row-cols-md-1 > * {
+    flex: 0 0 auto;
+    width: 100%;
+  }
+  .row-cols-md-2 > * {
+    flex: 0 0 auto;
+    width: 50%;
+  }
+  .row-cols-md-3 > * {
+    flex: 0 0 auto;
+    width: 33.33333333%;
+  }
+  .row-cols-md-4 > * {
+    flex: 0 0 auto;
+    width: 25%;
+  }
+  .row-cols-md-5 > * {
+    flex: 0 0 auto;
+    width: 20%;
+  }
+  .row-cols-md-6 > * {
+    flex: 0 0 auto;
+    width: 16.66666667%;
+  }
+  .col-md-auto {
+    flex: 0 0 auto;
+    width: auto;
+  }
+  .col-md-1 {
+    flex: 0 0 auto;
+    width: 8.33333333%;
+  }
+  .col-md-2 {
+    flex: 0 0 auto;
+    width: 16.66666667%;
+  }
+  .col-md-3 {
+    flex: 0 0 auto;
+    width: 25%;
+  }
+  .col-md-4 {
+    flex: 0 0 auto;
+    width: 33.33333333%;
+  }
+  .col-md-5 {
+    flex: 0 0 auto;
+    width: 41.66666667%;
+  }
+  .col-md-6 {
+    flex: 0 0 auto;
+    width: 50%;
+  }
+  .col-md-7 {
+    flex: 0 0 auto;
+    width: 58.33333333%;
+  }
+  .col-md-8 {
+    flex: 0 0 auto;
+    width: 66.66666667%;
+  }
+  .col-md-9 {
+    flex: 0 0 auto;
+    width: 75%;
+  }
+  .col-md-10 {
+    flex: 0 0 auto;
+    width: 83.33333333%;
+  }
+  .col-md-11 {
+    flex: 0 0 auto;
+    width: 91.66666667%;
+  }
+  .col-md-12 {
+    flex: 0 0 auto;
+    width: 100%;
+  }
+  .offset-md-0 {
+    margin-left: 0;
+  }
+  .offset-md-1 {
+    margin-left: 8.33333333%;
+  }
+  .offset-md-2 {
+    margin-left: 16.66666667%;
+  }
+  .offset-md-3 {
+    margin-left: 25%;
+  }
+  .offset-md-4 {
+    margin-left: 33.33333333%;
+  }
+  .offset-md-5 {
+    margin-left: 41.66666667%;
+  }
+  .offset-md-6 {
+    margin-left: 50%;
+  }
+  .offset-md-7 {
+    margin-left: 58.33333333%;
+  }
+  .offset-md-8 {
+    margin-left: 66.66666667%;
+  }
+  .offset-md-9 {
+    margin-left: 75%;
+  }
+  .offset-md-10 {
+    margin-left: 83.33333333%;
+  }
+  .offset-md-11 {
+    margin-left: 91.66666667%;
+  }
+  .g-md-0,
+  .gx-md-0 {
+    --bs-gutter-x: 0;
+  }
+  .g-md-0,
+  .gy-md-0 {
+    --bs-gutter-y: 0;
+  }
+  .g-md-1,
+  .gx-md-1 {
+    --bs-gutter-x: 0.25rem;
+  }
+  .g-md-1,
+  .gy-md-1 {
+    --bs-gutter-y: 0.25rem;
+  }
+  .g-md-2,
+  .gx-md-2 {
+    --bs-gutter-x: 0.5rem;
+  }
+  .g-md-2,
+  .gy-md-2 {
+    --bs-gutter-y: 0.5rem;
+  }
+  .g-md-3,
+  .gx-md-3 {
+    --bs-gutter-x: 1rem;
+  }
+  .g-md-3,
+  .gy-md-3 {
+    --bs-gutter-y: 1rem;
+  }
+  .g-md-4,
+  .gx-md-4 {
+    --bs-gutter-x: 1.5rem;
+  }
+  .g-md-4,
+  .gy-md-4 {
+    --bs-gutter-y: 1.5rem;
+  }
+  .g-md-5,
+  .gx-md-5 {
+    --bs-gutter-x: 3rem;
+  }
+  .g-md-5,
+  .gy-md-5 {
+    --bs-gutter-y: 3rem;
+  }
+}
+@media (min-width: 992px) {
+  .col-lg {
+    flex: 1 0 0;
+  }
+  .row-cols-lg-auto > * {
+    flex: 0 0 auto;
+    width: auto;
+  }
+  .row-cols-lg-1 > * {
+    flex: 0 0 auto;
+    width: 100%;
+  }
+  .row-cols-lg-2 > * {
+    flex: 0 0 auto;
+    width: 50%;
+  }
+  .row-cols-lg-3 > * {
+    flex: 0 0 auto;
+    width: 33.33333333%;
+  }
+  .row-cols-lg-4 > * {
+    flex: 0 0 auto;
+    width: 25%;
+  }
+  .row-cols-lg-5 > * {
+    flex: 0 0 auto;
+    width: 20%;
+  }
+  .row-cols-lg-6 > * {
+    flex: 0 0 auto;
+    width: 16.66666667%;
+  }
+  .col-lg-auto {
+    flex: 0 0 auto;
+    width: auto;
+  }
+  .col-lg-1 {
+    flex: 0 0 auto;
+    width: 8.33333333%;
+  }
+  .col-lg-2 {
+    flex: 0 0 auto;
+    width: 16.66666667%;
+  }
+  .col-lg-3 {
+    flex: 0 0 auto;
+    width: 25%;
+  }
+  .col-lg-4 {
+    flex: 0 0 auto;
+    width: 33.33333333%;
+  }
+  .col-lg-5 {
+    flex: 0 0 auto;
+    width: 41.66666667%;
+  }
+  .col-lg-6 {
+    flex: 0 0 auto;
+    width: 50%;
+  }
+  .col-lg-7 {
+    flex: 0 0 auto;
+    width: 58.33333333%;
+  }
+  .col-lg-8 {
+    flex: 0 0 auto;
+    width: 66.66666667%;
+  }
+  .col-lg-9 {
+    flex: 0 0 auto;
+    width: 75%;
+  }
+  .col-lg-10 {
+    flex: 0 0 auto;
+    width: 83.33333333%;
+  }
+  .col-lg-11 {
+    flex: 0 0 auto;
+    width: 91.66666667%;
+  }
+  .col-lg-12 {
+    flex: 0 0 auto;
+    width: 100%;
+  }
+  .offset-lg-0 {
+    margin-left: 0;
+  }
+  .offset-lg-1 {
+    margin-left: 8.33333333%;
+  }
+  .offset-lg-2 {
+    margin-left: 16.66666667%;
+  }
+  .offset-lg-3 {
+    margin-left: 25%;
+  }
+  .offset-lg-4 {
+    margin-left: 33.33333333%;
+  }
+  .offset-lg-5 {
+    margin-left: 41.66666667%;
+  }
+  .offset-lg-6 {
+    margin-left: 50%;
+  }
+  .offset-lg-7 {
+    margin-left: 58.33333333%;
+  }
+  .offset-lg-8 {
+    margin-left: 66.66666667%;
+  }
+  .offset-lg-9 {
+    margin-left: 75%;
+  }
+  .offset-lg-10 {
+    margin-left: 83.33333333%;
+  }
+  .offset-lg-11 {
+    margin-left: 91.66666667%;
+  }
+  .g-lg-0,
+  .gx-lg-0 {
+    --bs-gutter-x: 0;
+  }
+  .g-lg-0,
+  .gy-lg-0 {
+    --bs-gutter-y: 0;
+  }
+  .g-lg-1,
+  .gx-lg-1 {
+    --bs-gutter-x: 0.25rem;
+  }
+  .g-lg-1,
+  .gy-lg-1 {
+    --bs-gutter-y: 0.25rem;
+  }
+  .g-lg-2,
+  .gx-lg-2 {
+    --bs-gutter-x: 0.5rem;
+  }
+  .g-lg-2,
+  .gy-lg-2 {
+    --bs-gutter-y: 0.5rem;
+  }
+  .g-lg-3,
+  .gx-lg-3 {
+    --bs-gutter-x: 1rem;
+  }
+  .g-lg-3,
+  .gy-lg-3 {
+    --bs-gutter-y: 1rem;
+  }
+  .g-lg-4,
+  .gx-lg-4 {
+    --bs-gutter-x: 1.5rem;
+  }
+  .g-lg-4,
+  .gy-lg-4 {
+    --bs-gutter-y: 1.5rem;
+  }
+  .g-lg-5,
+  .gx-lg-5 {
+    --bs-gutter-x: 3rem;
+  }
+  .g-lg-5,
+  .gy-lg-5 {
+    --bs-gutter-y: 3rem;
+  }
+}
+@media (min-width: 1200px) {
+  .col-xl {
+    flex: 1 0 0;
+  }
+  .row-cols-xl-auto > * {
+    flex: 0 0 auto;
+    width: auto;
+  }
+  .row-cols-xl-1 > * {
+    flex: 0 0 auto;
+    width: 100%;
+  }
+  .row-cols-xl-2 > * {
+    flex: 0 0 auto;
+    width: 50%;
+  }
+  .row-cols-xl-3 > * {
+    flex: 0 0 auto;
+    width: 33.33333333%;
+  }
+  .row-cols-xl-4 > * {
+    flex: 0 0 auto;
+    width: 25%;
+  }
+  .row-cols-xl-5 > * {
+    flex: 0 0 auto;
+    width: 20%;
+  }
+  .row-cols-xl-6 > * {
+    flex: 0 0 auto;
+    width: 16.66666667%;
+  }
+  .col-xl-auto {
+    flex: 0 0 auto;
+    width: auto;
+  }
+  .col-xl-1 {
+    flex: 0 0 auto;
+    width: 8.33333333%;
+  }
+  .col-xl-2 {
+    flex: 0 0 auto;
+    width: 16.66666667%;
+  }
+  .col-xl-3 {
+    flex: 0 0 auto;
+    width: 25%;
+  }
+  .col-xl-4 {
+    flex: 0 0 auto;
+    width: 33.33333333%;
+  }
+  .col-xl-5 {
+    flex: 0 0 auto;
+    width: 41.66666667%;
+  }
+  .col-xl-6 {
+    flex: 0 0 auto;
+    width: 50%;
+  }
+  .col-xl-7 {
+    flex: 0 0 auto;
+    width: 58.33333333%;
+  }
+  .col-xl-8 {
+    flex: 0 0 auto;
+    width: 66.66666667%;
+  }
+  .col-xl-9 {
+    flex: 0 0 auto;
+    width: 75%;
+  }
+  .col-xl-10 {
+    flex: 0 0 auto;
+    width: 83.33333333%;
+  }
+  .col-xl-11 {
+    flex: 0 0 auto;
+    width: 91.66666667%;
+  }
+  .col-xl-12 {
+    flex: 0 0 auto;
+    width: 100%;
+  }
+  .offset-xl-0 {
+    margin-left: 0;
+  }
+  .offset-xl-1 {
+    margin-left: 8.33333333%;
+  }
+  .offset-xl-2 {
+    margin-left: 16.66666667%;
+  }
+  .offset-xl-3 {
+    margin-left: 25%;
+  }
+  .offset-xl-4 {
+    margin-left: 33.33333333%;
+  }
+  .offset-xl-5 {
+    margin-left: 41.66666667%;
+  }
+  .offset-xl-6 {
+    margin-left: 50%;
+  }
+  .offset-xl-7 {
+    margin-left: 58.33333333%;
+  }
+  .offset-xl-8 {
+    margin-left: 66.66666667%;
+  }
+  .offset-xl-9 {
+    margin-left: 75%;
+  }
+  .offset-xl-10 {
+    margin-left: 83.33333333%;
+  }
+  .offset-xl-11 {
+    margin-left: 91.66666667%;
+  }
+  .g-xl-0,
+  .gx-xl-0 {
+    --bs-gutter-x: 0;
+  }
+  .g-xl-0,
+  .gy-xl-0 {
+    --bs-gutter-y: 0;
+  }
+  .g-xl-1,
+  .gx-xl-1 {
+    --bs-gutter-x: 0.25rem;
+  }
+  .g-xl-1,
+  .gy-xl-1 {
+    --bs-gutter-y: 0.25rem;
+  }
+  .g-xl-2,
+  .gx-xl-2 {
+    --bs-gutter-x: 0.5rem;
+  }
+  .g-xl-2,
+  .gy-xl-2 {
+    --bs-gutter-y: 0.5rem;
+  }
+  .g-xl-3,
+  .gx-xl-3 {
+    --bs-gutter-x: 1rem;
+  }
+  .g-xl-3,
+  .gy-xl-3 {
+    --bs-gutter-y: 1rem;
+  }
+  .g-xl-4,
+  .gx-xl-4 {
+    --bs-gutter-x: 1.5rem;
+  }
+  .g-xl-4,
+  .gy-xl-4 {
+    --bs-gutter-y: 1.5rem;
+  }
+  .g-xl-5,
+  .gx-xl-5 {
+    --bs-gutter-x: 3rem;
+  }
+  .g-xl-5,
+  .gy-xl-5 {
+    --bs-gutter-y: 3rem;
+  }
+}
+@media (min-width: 1400px) {
+  .col-xxl {
+    flex: 1 0 0;
+  }
+  .row-cols-xxl-auto > * {
+    flex: 0 0 auto;
+    width: auto;
+  }
+  .row-cols-xxl-1 > * {
+    flex: 0 0 auto;
+    width: 100%;
+  }
+  .row-cols-xxl-2 > * {
+    flex: 0 0 auto;
+    width: 50%;
+  }
+  .row-cols-xxl-3 > * {
+    flex: 0 0 auto;
+    width: 33.33333333%;
+  }
+  .row-cols-xxl-4 > * {
+    flex: 0 0 auto;
+    width: 25%;
+  }
+  .row-cols-xxl-5 > * {
+    flex: 0 0 auto;
+    width: 20%;
+  }
+  .row-cols-xxl-6 > * {
+    flex: 0 0 auto;
+    width: 16.66666667%;
+  }
+  .col-xxl-auto {
+    flex: 0 0 auto;
+    width: auto;
+  }
+  .col-xxl-1 {
+    flex: 0 0 auto;
+    width: 8.33333333%;
+  }
+  .col-xxl-2 {
+    flex: 0 0 auto;
+    width: 16.66666667%;
+  }
+  .col-xxl-3 {
+    flex: 0 0 auto;
+    width: 25%;
+  }
+  .col-xxl-4 {
+    flex: 0 0 auto;
+    width: 33.33333333%;
+  }
+  .col-xxl-5 {
+    flex: 0 0 auto;
+    width: 41.66666667%;
+  }
+  .col-xxl-6 {
+    flex: 0 0 auto;
+    width: 50%;
+  }
+  .col-xxl-7 {
+    flex: 0 0 auto;
+    width: 58.33333333%;
+  }
+  .col-xxl-8 {
+    flex: 0 0 auto;
+    width: 66.66666667%;
+  }
+  .col-xxl-9 {
+    flex: 0 0 auto;
+    width: 75%;
+  }
+  .col-xxl-10 {
+    flex: 0 0 auto;
+    width: 83.33333333%;
+  }
+  .col-xxl-11 {
+    flex: 0 0 auto;
+    width: 91.66666667%;
+  }
+  .col-xxl-12 {
+    flex: 0 0 auto;
+    width: 100%;
+  }
+  .offset-xxl-0 {
+    margin-left: 0;
+  }
+  .offset-xxl-1 {
+    margin-left: 8.33333333%;
+  }
+  .offset-xxl-2 {
+    margin-left: 16.66666667%;
+  }
+  .offset-xxl-3 {
+    margin-left: 25%;
+  }
+  .offset-xxl-4 {
+    margin-left: 33.33333333%;
+  }
+  .offset-xxl-5 {
+    margin-left: 41.66666667%;
+  }
+  .offset-xxl-6 {
+    margin-left: 50%;
+  }
+  .offset-xxl-7 {
+    margin-left: 58.33333333%;
+  }
+  .offset-xxl-8 {
+    margin-left: 66.66666667%;
+  }
+  .offset-xxl-9 {
+    margin-left: 75%;
+  }
+  .offset-xxl-10 {
+    margin-left: 83.33333333%;
+  }
+  .offset-xxl-11 {
+    margin-left: 91.66666667%;
+  }
+  .g-xxl-0,
+  .gx-xxl-0 {
+    --bs-gutter-x: 0;
+  }
+  .g-xxl-0,
+  .gy-xxl-0 {
+    --bs-gutter-y: 0;
+  }
+  .g-xxl-1,
+  .gx-xxl-1 {
+    --bs-gutter-x: 0.25rem;
+  }
+  .g-xxl-1,
+  .gy-xxl-1 {
+    --bs-gutter-y: 0.25rem;
+  }
+  .g-xxl-2,
+  .gx-xxl-2 {
+    --bs-gutter-x: 0.5rem;
+  }
+  .g-xxl-2,
+  .gy-xxl-2 {
+    --bs-gutter-y: 0.5rem;
+  }
+  .g-xxl-3,
+  .gx-xxl-3 {
+    --bs-gutter-x: 1rem;
+  }
+  .g-xxl-3,
+  .gy-xxl-3 {
+    --bs-gutter-y: 1rem;
+  }
+  .g-xxl-4,
+  .gx-xxl-4 {
+    --bs-gutter-x: 1.5rem;
+  }
+  .g-xxl-4,
+  .gy-xxl-4 {
+    --bs-gutter-y: 1.5rem;
+  }
+  .g-xxl-5,
+  .gx-xxl-5 {
+    --bs-gutter-x: 3rem;
+  }
+  .g-xxl-5,
+  .gy-xxl-5 {
+    --bs-gutter-y: 3rem;
+  }
+}
+.table {
+  --bs-table-color-type: initial;
+  --bs-table-bg-type: initial;
+  --bs-table-color-state: initial;
+  --bs-table-bg-state: initial;
+  --bs-table-color: var(--bs-emphasis-color);
+  --bs-table-bg: var(--bs-body-bg);
+  --bs-table-border-color: var(--bs-border-color);
+  --bs-table-accent-bg: transparent;
+  --bs-table-striped-color: var(--bs-emphasis-color);
+  --bs-table-striped-bg: rgba(var(--bs-emphasis-color-rgb), 0.05);
+  --bs-table-active-color: var(--bs-emphasis-color);
+  --bs-table-active-bg: rgba(var(--bs-emphasis-color-rgb), 0.1);
+  --bs-table-hover-color: var(--bs-emphasis-color);
+  --bs-table-hover-bg: rgba(var(--bs-emphasis-color-rgb), 0.075);
+  width: 100%;
+  margin-bottom: 1rem;
+  vertical-align: top;
+  border-color: var(--bs-table-border-color);
+}
+.table > :not(caption) > * > * {
+  padding: 0.5rem 0.5rem;
+  color: var(--bs-table-color-state, var(--bs-table-color-type, var(--bs-table-color)));
+  background-color: var(--bs-table-bg);
+  border-bottom-width: var(--bs-border-width);
+  box-shadow: inset 0 0 0 9999px var(--bs-table-bg-state, var(--bs-table-bg-type, var(--bs-table-accent-bg)));
+}
+.table > tbody {
+  vertical-align: inherit;
+}
+.table > thead {
+  vertical-align: bottom;
+}
+
+.table-group-divider {
+  border-top: calc(var(--bs-border-width) * 2) solid currentcolor;
+}
+
+.caption-top {
+  caption-side: top;
+}
+
+.table-sm > :not(caption) > * > * {
+  padding: 0.25rem 0.25rem;
+}
+
+.table-bordered > :not(caption) > * {
+  border-width: var(--bs-border-width) 0;
+}
+.table-bordered > :not(caption) > * > * {
+  border-width: 0 var(--bs-border-width);
+}
+
+.table-borderless > :not(caption) > * > * {
+  border-bottom-width: 0;
+}
+.table-borderless > :not(:first-child) {
+  border-top-width: 0;
+}
+
+.table-striped > tbody > tr:nth-of-type(odd) > * {
+  --bs-table-color-type: var(--bs-table-striped-color);
+  --bs-table-bg-type: var(--bs-table-striped-bg);
+}
+
+.table-striped-columns > :not(caption) > tr > :nth-child(even) {
+  --bs-table-color-type: var(--bs-table-striped-color);
+  --bs-table-bg-type: var(--bs-table-striped-bg);
+}
+
+.table-active {
+  --bs-table-color-state: var(--bs-table-active-color);
+  --bs-table-bg-state: var(--bs-table-active-bg);
+}
+
+.table-hover > tbody > tr:hover > * {
+  --bs-table-color-state: var(--bs-table-hover-color);
+  --bs-table-bg-state: var(--bs-table-hover-bg);
+}
+
+.table-primary {
+  --bs-table-color: #000000;
+  --bs-table-bg: rgb(206, 209, 212.2);
+  --bs-table-border-color: rgb(164.8, 167.2, 169.76);
+  --bs-table-striped-bg: rgb(195.7, 198.55, 201.59);
+  --bs-table-striped-color: #000000;
+  --bs-table-active-bg: rgb(185.4, 188.1, 190.98);
+  --bs-table-active-color: #000000;
+  --bs-table-hover-bg: rgb(190.55, 193.325, 196.285);
+  --bs-table-hover-color: #000000;
+  color: var(--bs-table-color);
+  border-color: var(--bs-table-border-color);
+}
+
+.table-secondary {
+  --bs-table-color: #000000;
+  --bs-table-bg: rgb(208, 214, 220.4);
+  --bs-table-border-color: rgb(166.4, 171.2, 176.32);
+  --bs-table-striped-bg: rgb(197.6, 203.3, 209.38);
+  --bs-table-striped-color: #000000;
+  --bs-table-active-bg: rgb(187.2, 192.6, 198.36);
+  --bs-table-active-color: #000000;
+  --bs-table-hover-bg: rgb(192.4, 197.95, 203.87);
+  --bs-table-hover-color: #000000;
+  color: var(--bs-table-color);
+  border-color: var(--bs-table-border-color);
+}
+
+.table-success {
+  --bs-table-color: #000000;
+  --bs-table-bg: rgb(209, 231, 220.8);
+  --bs-table-border-color: rgb(167.2, 184.8, 176.64);
+  --bs-table-striped-bg: rgb(198.55, 219.45, 209.76);
+  --bs-table-striped-color: #000000;
+  --bs-table-active-bg: rgb(188.1, 207.9, 198.72);
+  --bs-table-active-color: #000000;
+  --bs-table-hover-bg: rgb(193.325, 213.675, 204.24);
+  --bs-table-hover-color: #000000;
+  color: var(--bs-table-color);
+  border-color: var(--bs-table-border-color);
+}
+
+.table-info {
+  --bs-table-color: #000000;
+  --bs-table-bg: rgb(206.6, 244.4, 252);
+  --bs-table-border-color: rgb(165.28, 195.52, 201.6);
+  --bs-table-striped-bg: rgb(196.27, 232.18, 239.4);
+  --bs-table-striped-color: #000000;
+  --bs-table-active-bg: rgb(185.94, 219.96, 226.8);
+  --bs-table-active-color: #000000;
+  --bs-table-hover-bg: rgb(191.105, 226.07, 233.1);
+  --bs-table-hover-color: #000000;
+  color: var(--bs-table-color);
+  border-color: var(--bs-table-border-color);
+}
+
+.table-warning {
+  --bs-table-color: #000000;
+  --bs-table-bg: rgb(255, 242.6, 205.4);
+  --bs-table-border-color: rgb(204, 194.08, 164.32);
+  --bs-table-striped-bg: rgb(242.25, 230.47, 195.13);
+  --bs-table-striped-color: #000000;
+  --bs-table-active-bg: rgb(229.5, 218.34, 184.86);
+  --bs-table-active-color: #000000;
+  --bs-table-hover-bg: rgb(235.875, 224.405, 189.995);
+  --bs-table-hover-color: #000000;
+  color: var(--bs-table-color);
+  border-color: var(--bs-table-border-color);
+}
+
+.table-danger {
+  --bs-table-color: #000000;
+  --bs-table-bg: rgb(245.6, 208.8, 210);
+  --bs-table-border-color: rgb(196.48, 167.04, 168);
+  --bs-table-striped-bg: rgb(233.32, 198.36, 199.5);
+  --bs-table-striped-color: #000000;
+  --bs-table-active-bg: rgb(221.04, 187.92, 189);
+  --bs-table-active-color: #000000;
+  --bs-table-hover-bg: rgb(227.18, 193.14, 194.25);
+  --bs-table-hover-color: #000000;
+  color: var(--bs-table-color);
+  border-color: var(--bs-table-border-color);
+}
+
+.table-light {
+  --bs-table-color: #000000;
+  --bs-table-bg: #f8f9fa;
+  --bs-table-border-color: rgb(198.4, 199.2, 200);
+  --bs-table-striped-bg: rgb(235.6, 236.55, 237.5);
+  --bs-table-striped-color: #000000;
+  --bs-table-active-bg: rgb(223.2, 224.1, 225);
+  --bs-table-active-color: #000000;
+  --bs-table-hover-bg: rgb(229.4, 230.325, 231.25);
+  --bs-table-hover-color: #000000;
+  color: var(--bs-table-color);
+  border-color: var(--bs-table-border-color);
+}
+
+.table-dark {
+  --bs-table-color: #ffffff;
+  --bs-table-bg: #212529;
+  --bs-table-border-color: rgb(77.4, 80.6, 83.8);
+  --bs-table-striped-bg: rgb(44.1, 47.9, 51.7);
+  --bs-table-striped-color: #ffffff;
+  --bs-table-active-bg: rgb(55.2, 58.8, 62.4);
+  --bs-table-active-color: #ffffff;
+  --bs-table-hover-bg: rgb(49.65, 53.35, 57.05);
+  --bs-table-hover-color: #ffffff;
+  color: var(--bs-table-color);
+  border-color: var(--bs-table-border-color);
+}
+
+.table-responsive {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+@media (max-width: 575.98px) {
+  .table-responsive-sm {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+@media (max-width: 767.98px) {
+  .table-responsive-md {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+@media (max-width: 991.98px) {
+  .table-responsive-lg {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+@media (max-width: 1199.98px) {
+  .table-responsive-xl {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+@media (max-width: 1399.98px) {
+  .table-responsive-xxl {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+.form-label {
+  margin-bottom: 0.5rem;
+}
+
+.col-form-label {
+  padding-top: calc(0.375rem + var(--bs-border-width));
+  padding-bottom: calc(0.375rem + var(--bs-border-width));
+  margin-bottom: 0;
+  font-size: inherit;
+  line-height: 1.5;
+}
+
+.col-form-label-lg {
+  padding-top: calc(0.5rem + var(--bs-border-width));
+  padding-bottom: calc(0.5rem + var(--bs-border-width));
+  font-size: 1.25rem;
+}
+
+.col-form-label-sm {
+  padding-top: calc(0.25rem + var(--bs-border-width));
+  padding-bottom: calc(0.25rem + var(--bs-border-width));
+  font-size: 0.875rem;
+}
+
+.form-text {
+  margin-top: 0.25rem;
+  font-size: 0.875em;
+  color: var(--bs-secondary-color);
+}
+
+.form-control {
+  display: block;
+  width: 100%;
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--bs-body-color);
+  appearance: none;
+  background-color: var(--bs-body-bg);
+  background-clip: padding-box;
+  border: var(--bs-border-width) solid var(--bs-border-color);
+  border-radius: var(--bs-border-radius);
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .form-control {
+    transition: none;
+  }
+}
+.form-control[type=file] {
+  overflow: hidden;
+}
+.form-control[type=file]:not(:disabled):not([readonly]) {
+  cursor: pointer;
+}
+.form-control:focus {
+  color: var(--bs-body-color);
+  background-color: var(--bs-body-bg);
+  border-color: rgb(132.5, 140, 148);
+  outline: 0;
+  box-shadow: 0 0 0 0.25rem rgba(10, 25, 41, 0.25);
+}
+.form-control::-webkit-date-and-time-value {
+  min-width: 85px;
+  height: 1.5em;
+  margin: 0;
+}
+.form-control::-webkit-datetime-edit {
+  display: block;
+  padding: 0;
+}
+.form-control::placeholder {
+  color: var(--bs-secondary-color);
+  opacity: 1;
+}
+.form-control:disabled {
+  background-color: var(--bs-secondary-bg);
+  opacity: 1;
+}
+.form-control::file-selector-button {
+  padding: 0.375rem 0.75rem;
+  margin: -0.375rem -0.75rem;
+  margin-inline-end: 0.75rem;
+  color: var(--bs-body-color);
+  background-color: var(--bs-tertiary-bg);
+  pointer-events: none;
+  border-color: inherit;
+  border-style: solid;
+  border-width: 0;
+  border-inline-end-width: var(--bs-border-width);
+  border-radius: 0;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .form-control::file-selector-button {
+    transition: none;
+  }
+}
+.form-control:hover:not(:disabled):not([readonly])::file-selector-button {
+  background-color: var(--bs-secondary-bg);
+}
+
+.form-control-plaintext {
+  display: block;
+  width: 100%;
+  padding: 0.375rem 0;
+  margin-bottom: 0;
+  line-height: 1.5;
+  color: var(--bs-body-color);
+  background-color: transparent;
+  border: solid transparent;
+  border-width: var(--bs-border-width) 0;
+}
+.form-control-plaintext:focus {
+  outline: 0;
+}
+.form-control-plaintext.form-control-sm, .form-control-plaintext.form-control-lg {
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.form-control-sm {
+  min-height: calc(1.5em + 0.5rem + calc(var(--bs-border-width) * 2));
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  border-radius: var(--bs-border-radius-sm);
+}
+.form-control-sm::file-selector-button {
+  padding: 0.25rem 0.5rem;
+  margin: -0.25rem -0.5rem;
+  margin-inline-end: 0.5rem;
+}
+
+.form-control-lg {
+  min-height: calc(1.5em + 1rem + calc(var(--bs-border-width) * 2));
+  padding: 0.5rem 1rem;
+  font-size: 1.25rem;
+  border-radius: var(--bs-border-radius-lg);
+}
+.form-control-lg::file-selector-button {
+  padding: 0.5rem 1rem;
+  margin: -0.5rem -1rem;
+  margin-inline-end: 1rem;
+}
+
+textarea.form-control {
+  min-height: calc(1.5em + 0.75rem + calc(var(--bs-border-width) * 2));
+}
+textarea.form-control-sm {
+  min-height: calc(1.5em + 0.5rem + calc(var(--bs-border-width) * 2));
+}
+textarea.form-control-lg {
+  min-height: calc(1.5em + 1rem + calc(var(--bs-border-width) * 2));
+}
+
+.form-control-color {
+  width: 3rem;
+  height: calc(1.5em + 0.75rem + calc(var(--bs-border-width) * 2));
+  padding: 0.375rem;
+}
+.form-control-color:not(:disabled):not([readonly]) {
+  cursor: pointer;
+}
+.form-control-color::-moz-color-swatch {
+  border: 0 !important;
+  border-radius: var(--bs-border-radius);
+}
+.form-control-color::-webkit-color-swatch {
+  border: 0 !important;
+  border-radius: var(--bs-border-radius);
+}
+.form-control-color.form-control-sm {
+  height: calc(1.5em + 0.5rem + calc(var(--bs-border-width) * 2));
+}
+.form-control-color.form-control-lg {
+  height: calc(1.5em + 1rem + calc(var(--bs-border-width) * 2));
+}
+
+.form-select {
+  --bs-form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
+  display: block;
+  width: 100%;
+  padding: 0.375rem 2.25rem 0.375rem 0.75rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--bs-body-color);
+  appearance: none;
+  background-color: var(--bs-body-bg);
+  background-image: var(--bs-form-select-bg-img), var(--bs-form-select-bg-icon, none);
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size: 16px 12px;
+  border: var(--bs-border-width) solid var(--bs-border-color);
+  border-radius: var(--bs-border-radius);
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .form-select {
+    transition: none;
+  }
+}
+.form-select:focus {
+  border-color: rgb(132.5, 140, 148);
+  outline: 0;
+  box-shadow: 0 0 0 0.25rem rgba(10, 25, 41, 0.25);
+}
+.form-select[multiple], .form-select[size]:not([size="1"]) {
+  padding-right: 0.75rem;
+  background-image: none;
+}
+.form-select:disabled {
+  background-color: var(--bs-secondary-bg);
+}
+.form-select:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 var(--bs-body-color);
+}
+
+.form-select-sm {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  padding-left: 0.5rem;
+  font-size: 0.875rem;
+  border-radius: var(--bs-border-radius-sm);
+}
+
+.form-select-lg {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 1rem;
+  font-size: 1.25rem;
+  border-radius: var(--bs-border-radius-lg);
+}
+
+[data-bs-theme=dark] .form-select {
+  --bs-form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23dee2e6' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
+}
+
+.form-check {
+  display: block;
+  min-height: 1.5rem;
+  padding-left: 1.5em;
+  margin-bottom: 0.125rem;
+}
+.form-check .form-check-input {
+  float: left;
+  margin-left: -1.5em;
+}
+
+.form-check-reverse {
+  padding-right: 1.5em;
+  padding-left: 0;
+  text-align: right;
+}
+.form-check-reverse .form-check-input {
+  float: right;
+  margin-right: -1.5em;
+  margin-left: 0;
+}
+
+.form-check-input {
+  --bs-form-check-bg: var(--bs-body-bg);
+  flex-shrink: 0;
+  width: 1em;
+  height: 1em;
+  margin-top: 0.25em;
+  vertical-align: top;
+  appearance: none;
+  background-color: var(--bs-form-check-bg);
+  background-image: var(--bs-form-check-bg-image);
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  border: var(--bs-border-width) solid var(--bs-border-color);
+  print-color-adjust: exact;
+}
+.form-check-input[type=checkbox] {
+  border-radius: 0.25em;
+}
+.form-check-input[type=radio] {
+  border-radius: 50%;
+}
+.form-check-input:active {
+  filter: brightness(90%);
+}
+.form-check-input:focus {
+  border-color: rgb(132.5, 140, 148);
+  outline: 0;
+  box-shadow: 0 0 0 0.25rem rgba(10, 25, 41, 0.25);
+}
+.form-check-input:checked {
+  background-color: #0A1929;
+  border-color: #0A1929;
+}
+.form-check-input:checked[type=checkbox] {
+  --bs-form-check-bg-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='%23ffffff' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='m6 10 3 3 6-6'/%3e%3c/svg%3e");
+}
+.form-check-input:checked[type=radio] {
+  --bs-form-check-bg-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='2' fill='%23ffffff'/%3e%3c/svg%3e");
+}
+.form-check-input[type=checkbox]:indeterminate {
+  background-color: #0A1929;
+  border-color: #0A1929;
+  --bs-form-check-bg-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='%23ffffff' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/%3e%3c/svg%3e");
+}
+.form-check-input:disabled {
+  pointer-events: none;
+  filter: none;
+  opacity: 0.5;
+}
+.form-check-input[disabled] ~ .form-check-label, .form-check-input:disabled ~ .form-check-label {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.form-switch {
+  padding-left: 2.5em;
+}
+.form-switch .form-check-input {
+  --bs-form-switch-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgba%280, 0, 0, 0.25%29'/%3e%3c/svg%3e");
+  width: 2em;
+  margin-left: -2.5em;
+  background-image: var(--bs-form-switch-bg);
+  background-position: left center;
+  border-radius: 2em;
+  transition: background-position 0.15s ease-in-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .form-switch .form-check-input {
+    transition: none;
+  }
+}
+.form-switch .form-check-input:focus {
+  --bs-form-switch-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgb%28132.5, 140, 148%29'/%3e%3c/svg%3e");
+}
+.form-switch .form-check-input:checked {
+  background-position: right center;
+  --bs-form-switch-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23ffffff'/%3e%3c/svg%3e");
+}
+.form-switch.form-check-reverse {
+  padding-right: 2.5em;
+  padding-left: 0;
+}
+.form-switch.form-check-reverse .form-check-input {
+  margin-right: -2.5em;
+  margin-left: 0;
+}
+
+.form-check-inline {
+  display: inline-block;
+  margin-right: 1rem;
+}
+
+.btn-check {
+  position: absolute;
+  clip: rect(0, 0, 0, 0);
+  pointer-events: none;
+}
+.btn-check[disabled] + .btn, .btn-check:disabled + .btn {
+  pointer-events: none;
+  filter: none;
+  opacity: 0.65;
+}
+
+[data-bs-theme=dark] .form-switch .form-check-input:not(:checked):not(:focus) {
+  --bs-form-switch-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgba%28255, 255, 255, 0.25%29'/%3e%3c/svg%3e");
+}
+
+.form-range {
+  width: 100%;
+  height: 1.5rem;
+  padding: 0;
+  appearance: none;
+  background-color: transparent;
+}
+.form-range:focus {
+  outline: 0;
+}
+.form-range:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px #ffffff, 0 0 0 0.25rem rgba(10, 25, 41, 0.25);
+}
+.form-range:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 1px #ffffff, 0 0 0 0.25rem rgba(10, 25, 41, 0.25);
+}
+.form-range::-moz-focus-outer {
+  border: 0;
+}
+.form-range::-webkit-slider-thumb {
+  width: 1rem;
+  height: 1rem;
+  margin-top: -0.25rem;
+  appearance: none;
+  background-color: #0A1929;
+  border: 0;
+  border-radius: 1rem;
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .form-range::-webkit-slider-thumb {
+    transition: none;
+  }
+}
+.form-range::-webkit-slider-thumb:active {
+  background-color: rgb(181.5, 186, 190.8);
+}
+.form-range::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 0.5rem;
+  color: transparent;
+  cursor: pointer;
+  background-color: var(--bs-secondary-bg);
+  border-color: transparent;
+  border-radius: 1rem;
+}
+.form-range::-moz-range-thumb {
+  width: 1rem;
+  height: 1rem;
+  appearance: none;
+  background-color: #0A1929;
+  border: 0;
+  border-radius: 1rem;
+  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .form-range::-moz-range-thumb {
+    transition: none;
+  }
+}
+.form-range::-moz-range-thumb:active {
+  background-color: rgb(181.5, 186, 190.8);
+}
+.form-range::-moz-range-track {
+  width: 100%;
+  height: 0.5rem;
+  color: transparent;
+  cursor: pointer;
+  background-color: var(--bs-secondary-bg);
+  border-color: transparent;
+  border-radius: 1rem;
+}
+.form-range:disabled {
+  pointer-events: none;
+}
+.form-range:disabled::-webkit-slider-thumb {
+  background-color: var(--bs-secondary-color);
+}
+.form-range:disabled::-moz-range-thumb {
+  background-color: var(--bs-secondary-color);
+}
+
+.form-floating {
+  position: relative;
+}
+.form-floating > .form-control,
+.form-floating > .form-control-plaintext,
+.form-floating > .form-select {
+  height: calc(3.5rem + calc(var(--bs-border-width) * 2));
+  min-height: calc(3.5rem + calc(var(--bs-border-width) * 2));
+  line-height: 1.25;
+}
+.form-floating > label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 2;
+  max-width: 100%;
+  height: 100%;
+  padding: 1rem 0.75rem;
+  overflow: hidden;
+  color: rgba(var(--bs-body-color-rgb), 0.65);
+  text-align: start;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  pointer-events: none;
+  border: var(--bs-border-width) solid transparent;
+  transform-origin: 0 0;
+  transition: opacity 0.1s ease-in-out, transform 0.1s ease-in-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .form-floating > label {
+    transition: none;
+  }
+}
+.form-floating > .form-control,
+.form-floating > .form-control-plaintext {
+  padding: 1rem 0.75rem;
+}
+.form-floating > .form-control::placeholder,
+.form-floating > .form-control-plaintext::placeholder {
+  color: transparent;
+}
+.form-floating > .form-control:focus, .form-floating > .form-control:not(:placeholder-shown),
+.form-floating > .form-control-plaintext:focus,
+.form-floating > .form-control-plaintext:not(:placeholder-shown) {
+  padding-top: 1.625rem;
+  padding-bottom: 0.625rem;
+}
+.form-floating > .form-control:-webkit-autofill,
+.form-floating > .form-control-plaintext:-webkit-autofill {
+  padding-top: 1.625rem;
+  padding-bottom: 0.625rem;
+}
+.form-floating > .form-select {
+  padding-top: 1.625rem;
+  padding-bottom: 0.625rem;
+  padding-left: 0.75rem;
+}
+.form-floating > .form-control:focus ~ label,
+.form-floating > .form-control:not(:placeholder-shown) ~ label,
+.form-floating > .form-control-plaintext ~ label,
+.form-floating > .form-select ~ label {
+  transform: scale(0.85) translateY(-0.5rem) translateX(0.15rem);
+}
+.form-floating > .form-control:-webkit-autofill ~ label {
+  transform: scale(0.85) translateY(-0.5rem) translateX(0.15rem);
+}
+.form-floating > textarea:focus ~ label::after,
+.form-floating > textarea:not(:placeholder-shown) ~ label::after {
+  position: absolute;
+  inset: 1rem 0.375rem;
+  z-index: -1;
+  height: 1.5em;
+  content: "";
+  background-color: var(--bs-body-bg);
+  border-radius: var(--bs-border-radius);
+}
+.form-floating > textarea:disabled ~ label::after {
+  background-color: var(--bs-secondary-bg);
+}
+.form-floating > .form-control-plaintext ~ label {
+  border-width: var(--bs-border-width) 0;
+}
+.form-floating > :disabled ~ label,
+.form-floating > .form-control:disabled ~ label {
+  color: #6c757d;
+}
+
+.input-group {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  width: 100%;
+}
+.input-group > .form-control,
+.input-group > .form-select,
+.input-group > .form-floating {
+  position: relative;
+  flex: 1 1 auto;
+  width: 1%;
+  min-width: 0;
+}
+.input-group > .form-control:focus,
+.input-group > .form-select:focus,
+.input-group > .form-floating:focus-within {
+  z-index: 5;
+}
+.input-group .btn {
+  position: relative;
+  z-index: 2;
+}
+.input-group .btn:focus {
+  z-index: 5;
+}
+
+.input-group-text {
+  display: flex;
+  align-items: center;
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--bs-body-color);
+  text-align: center;
+  white-space: nowrap;
+  background-color: var(--bs-tertiary-bg);
+  border: var(--bs-border-width) solid var(--bs-border-color);
+  border-radius: var(--bs-border-radius);
+}
+
+.input-group-lg > .form-control,
+.input-group-lg > .form-select,
+.input-group-lg > .input-group-text,
+.input-group-lg > .btn {
+  padding: 0.5rem 1rem;
+  font-size: 1.25rem;
+  border-radius: var(--bs-border-radius-lg);
+}
+
+.input-group-sm > .form-control,
+.input-group-sm > .form-select,
+.input-group-sm > .input-group-text,
+.input-group-sm > .btn {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  border-radius: var(--bs-border-radius-sm);
+}
+
+.input-group-lg > .form-select,
+.input-group-sm > .form-select {
+  padding-right: 3rem;
+}
+
+.input-group:not(.has-validation) > :not(:last-child):not(.dropdown-toggle):not(.dropdown-menu):not(.form-floating),
+.input-group:not(.has-validation) > .dropdown-toggle:nth-last-child(n+3),
+.input-group:not(.has-validation) > .form-floating:not(:last-child) > .form-control,
+.input-group:not(.has-validation) > .form-floating:not(:last-child) > .form-select {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.input-group.has-validation > :nth-last-child(n+3):not(.dropdown-toggle):not(.dropdown-menu):not(.form-floating),
+.input-group.has-validation > .dropdown-toggle:nth-last-child(n+4),
+.input-group.has-validation > .form-floating:nth-last-child(n+3) > .form-control,
+.input-group.has-validation > .form-floating:nth-last-child(n+3) > .form-select {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.input-group > :not(:first-child):not(.dropdown-menu):not(.valid-tooltip):not(.valid-feedback):not(.invalid-tooltip):not(.invalid-feedback) {
+  margin-left: calc(-1 * var(--bs-border-width));
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.input-group > .form-floating:not(:first-child) > .form-control,
+.input-group > .form-floating:not(:first-child) > .form-select {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.valid-feedback {
+  display: none;
+  width: 100%;
+  margin-top: 0.25rem;
+  font-size: 0.875em;
+  color: var(--bs-form-valid-color);
+}
+
+.valid-tooltip {
+  position: absolute;
+  top: 100%;
+  z-index: 5;
+  display: none;
+  max-width: 100%;
+  padding: 0.25rem 0.5rem;
+  margin-top: 0.1rem;
+  font-size: 0.875rem;
+  color: #fff;
+  background-color: var(--bs-success);
+  border-radius: var(--bs-border-radius);
+}
+
+.was-validated :valid ~ .valid-feedback,
+.was-validated :valid ~ .valid-tooltip,
+.is-valid ~ .valid-feedback,
+.is-valid ~ .valid-tooltip {
+  display: block;
+}
+
+.was-validated .form-control:valid, .form-control.is-valid {
+  border-color: var(--bs-form-valid-border-color);
+  padding-right: calc(1.5em + 0.75rem);
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%23198754' d='M2.3 6.73.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1'/%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+  background-position: right calc(0.375em + 0.1875rem) center;
+  background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+}
+.was-validated .form-control:valid:focus, .form-control.is-valid:focus {
+  border-color: var(--bs-form-valid-border-color);
+  box-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
+}
+
+.was-validated textarea.form-control:valid, textarea.form-control.is-valid {
+  padding-right: calc(1.5em + 0.75rem);
+  background-position: top calc(0.375em + 0.1875rem) right calc(0.375em + 0.1875rem);
+}
+
+.was-validated .form-select:valid, .form-select.is-valid {
+  border-color: var(--bs-form-valid-border-color);
+}
+.was-validated .form-select:valid:not([multiple]):not([size]), .was-validated .form-select:valid:not([multiple])[size="1"], .form-select.is-valid:not([multiple]):not([size]), .form-select.is-valid:not([multiple])[size="1"] {
+  --bs-form-select-bg-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%23198754' d='M2.3 6.73.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1'/%3e%3c/svg%3e");
+  padding-right: 4.125rem;
+  background-position: right 0.75rem center, center right 2.25rem;
+  background-size: 16px 12px, calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+}
+.was-validated .form-select:valid:focus, .form-select.is-valid:focus {
+  border-color: var(--bs-form-valid-border-color);
+  box-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
+}
+
+.was-validated .form-control-color:valid, .form-control-color.is-valid {
+  width: calc(3rem + calc(1.5em + 0.75rem));
+}
+
+.was-validated .form-check-input:valid, .form-check-input.is-valid {
+  border-color: var(--bs-form-valid-border-color);
+}
+.was-validated .form-check-input:valid:checked, .form-check-input.is-valid:checked {
+  background-color: var(--bs-form-valid-color);
+}
+.was-validated .form-check-input:valid:focus, .form-check-input.is-valid:focus {
+  box-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
+}
+.was-validated .form-check-input:valid ~ .form-check-label, .form-check-input.is-valid ~ .form-check-label {
+  color: var(--bs-form-valid-color);
+}
+
+.form-check-inline .form-check-input ~ .valid-feedback {
+  margin-left: 0.5em;
+}
+
+.was-validated .input-group > .form-control:not(:focus):valid, .input-group > .form-control:not(:focus).is-valid,
+.was-validated .input-group > .form-select:not(:focus):valid,
+.input-group > .form-select:not(:focus).is-valid,
+.was-validated .input-group > .form-floating:not(:focus-within):valid,
+.input-group > .form-floating:not(:focus-within).is-valid {
+  z-index: 3;
+}
+
+.invalid-feedback {
+  display: none;
+  width: 100%;
+  margin-top: 0.25rem;
+  font-size: 0.875em;
+  color: var(--bs-form-invalid-color);
+}
+
+.invalid-tooltip {
+  position: absolute;
+  top: 100%;
+  z-index: 5;
+  display: none;
+  max-width: 100%;
+  padding: 0.25rem 0.5rem;
+  margin-top: 0.1rem;
+  font-size: 0.875rem;
+  color: #fff;
+  background-color: var(--bs-danger);
+  border-radius: var(--bs-border-radius);
+}
+
+.was-validated :invalid ~ .invalid-feedback,
+.was-validated :invalid ~ .invalid-tooltip,
+.is-invalid ~ .invalid-feedback,
+.is-invalid ~ .invalid-tooltip {
+  display: block;
+}
+
+.was-validated .form-control:invalid, .form-control.is-invalid {
+  border-color: var(--bs-form-invalid-border-color);
+  padding-right: calc(1.5em + 0.75rem);
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23d0181e'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23d0181e' stroke='none'/%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+  background-position: right calc(0.375em + 0.1875rem) center;
+  background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+}
+.was-validated .form-control:invalid:focus, .form-control.is-invalid:focus {
+  border-color: var(--bs-form-invalid-border-color);
+  box-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
+}
+
+.was-validated textarea.form-control:invalid, textarea.form-control.is-invalid {
+  padding-right: calc(1.5em + 0.75rem);
+  background-position: top calc(0.375em + 0.1875rem) right calc(0.375em + 0.1875rem);
+}
+
+.was-validated .form-select:invalid, .form-select.is-invalid {
+  border-color: var(--bs-form-invalid-border-color);
+}
+.was-validated .form-select:invalid:not([multiple]):not([size]), .was-validated .form-select:invalid:not([multiple])[size="1"], .form-select.is-invalid:not([multiple]):not([size]), .form-select.is-invalid:not([multiple])[size="1"] {
+  --bs-form-select-bg-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23d0181e'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23d0181e' stroke='none'/%3e%3c/svg%3e");
+  padding-right: 4.125rem;
+  background-position: right 0.75rem center, center right 2.25rem;
+  background-size: 16px 12px, calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+}
+.was-validated .form-select:invalid:focus, .form-select.is-invalid:focus {
+  border-color: var(--bs-form-invalid-border-color);
+  box-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
+}
+
+.was-validated .form-control-color:invalid, .form-control-color.is-invalid {
+  width: calc(3rem + calc(1.5em + 0.75rem));
+}
+
+.was-validated .form-check-input:invalid, .form-check-input.is-invalid {
+  border-color: var(--bs-form-invalid-border-color);
+}
+.was-validated .form-check-input:invalid:checked, .form-check-input.is-invalid:checked {
+  background-color: var(--bs-form-invalid-color);
+}
+.was-validated .form-check-input:invalid:focus, .form-check-input.is-invalid:focus {
+  box-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
+}
+.was-validated .form-check-input:invalid ~ .form-check-label, .form-check-input.is-invalid ~ .form-check-label {
+  color: var(--bs-form-invalid-color);
+}
+
+.form-check-inline .form-check-input ~ .invalid-feedback {
+  margin-left: 0.5em;
+}
+
+.was-validated .input-group > .form-control:not(:focus):invalid, .input-group > .form-control:not(:focus).is-invalid,
+.was-validated .input-group > .form-select:not(:focus):invalid,
+.input-group > .form-select:not(:focus).is-invalid,
+.was-validated .input-group > .form-floating:not(:focus-within):invalid,
+.input-group > .form-floating:not(:focus-within).is-invalid {
+  z-index: 4;
+}
+
+.btn {
+  --bs-btn-padding-x: 0.75rem;
+  --bs-btn-padding-y: 0.375rem;
+  --bs-btn-font-family: ;
+  --bs-btn-font-size: 1rem;
+  --bs-btn-font-weight: 400;
+  --bs-btn-line-height: 1.5;
+  --bs-btn-color: var(--bs-body-color);
+  --bs-btn-bg: transparent;
+  --bs-btn-border-width: var(--bs-border-width);
+  --bs-btn-border-color: transparent;
+  --bs-btn-border-radius: var(--bs-border-radius);
+  --bs-btn-hover-border-color: transparent;
+  --bs-btn-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15), 0 1px 1px rgba(0, 0, 0, 0.075);
+  --bs-btn-disabled-opacity: 0.65;
+  --bs-btn-focus-box-shadow: 0 0 0 0.25rem rgba(var(--bs-btn-focus-shadow-rgb), .5);
+  display: inline-block;
+  padding: var(--bs-btn-padding-y) var(--bs-btn-padding-x);
+  font-family: var(--bs-btn-font-family);
+  font-size: var(--bs-btn-font-size);
+  font-weight: var(--bs-btn-font-weight);
+  line-height: var(--bs-btn-line-height);
+  color: var(--bs-btn-color);
+  text-align: center;
+  text-decoration: none;
+  vertical-align: middle;
+  cursor: pointer;
+  user-select: none;
+  border: var(--bs-btn-border-width) solid var(--bs-btn-border-color);
+  border-radius: var(--bs-btn-border-radius);
+  background-color: var(--bs-btn-bg);
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .btn {
+    transition: none;
+  }
+}
+.btn:hover {
+  color: var(--bs-btn-hover-color);
+  background-color: var(--bs-btn-hover-bg);
+  border-color: var(--bs-btn-hover-border-color);
+}
+.btn-check + .btn:hover {
+  color: var(--bs-btn-color);
+  background-color: var(--bs-btn-bg);
+  border-color: var(--bs-btn-border-color);
+}
+.btn:focus-visible {
+  color: var(--bs-btn-hover-color);
+  background-color: var(--bs-btn-hover-bg);
+  border-color: var(--bs-btn-hover-border-color);
+  outline: 0;
+  box-shadow: var(--bs-btn-focus-box-shadow);
+}
+.btn-check:focus-visible + .btn {
+  border-color: var(--bs-btn-hover-border-color);
+  outline: 0;
+  box-shadow: var(--bs-btn-focus-box-shadow);
+}
+.btn-check:checked + .btn, :not(.btn-check) + .btn:active, .btn:first-child:active, .btn.active, .btn.show {
+  color: var(--bs-btn-active-color);
+  background-color: var(--bs-btn-active-bg);
+  border-color: var(--bs-btn-active-border-color);
+}
+.btn-check:checked + .btn:focus-visible, :not(.btn-check) + .btn:active:focus-visible, .btn:first-child:active:focus-visible, .btn.active:focus-visible, .btn.show:focus-visible {
+  box-shadow: var(--bs-btn-focus-box-shadow);
+}
+.btn-check:checked:focus-visible + .btn {
+  box-shadow: var(--bs-btn-focus-box-shadow);
+}
+.btn:disabled, .btn.disabled, fieldset:disabled .btn {
+  color: var(--bs-btn-disabled-color);
+  pointer-events: none;
+  background-color: var(--bs-btn-disabled-bg);
+  border-color: var(--bs-btn-disabled-border-color);
+  opacity: var(--bs-btn-disabled-opacity);
+}
+
+.btn-primary {
+  --bs-btn-color: #ffffff;
+  --bs-btn-bg: #0A1929;
+  --bs-btn-border-color: #0A1929;
+  --bs-btn-hover-color: #ffffff;
+  --bs-btn-hover-bg: rgb(8.5, 21.25, 34.85);
+  --bs-btn-hover-border-color: rgb(8, 20, 32.8);
+  --bs-btn-focus-shadow-rgb: 47, 60, 73;
+  --bs-btn-active-color: #ffffff;
+  --bs-btn-active-bg: rgb(8, 20, 32.8);
+  --bs-btn-active-border-color: rgb(7.5, 18.75, 30.75);
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #ffffff;
+  --bs-btn-disabled-bg: #0A1929;
+  --bs-btn-disabled-border-color: #0A1929;
+}
+
+.btn-secondary {
+  --bs-btn-color: #ffffff;
+  --bs-btn-bg: #143252;
+  --bs-btn-border-color: #143252;
+  --bs-btn-hover-color: #ffffff;
+  --bs-btn-hover-bg: rgb(17, 42.5, 69.7);
+  --bs-btn-hover-border-color: rgb(16, 40, 65.6);
+  --bs-btn-focus-shadow-rgb: 55, 81, 108;
+  --bs-btn-active-color: #ffffff;
+  --bs-btn-active-bg: rgb(16, 40, 65.6);
+  --bs-btn-active-border-color: rgb(15, 37.5, 61.5);
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #ffffff;
+  --bs-btn-disabled-bg: #143252;
+  --bs-btn-disabled-border-color: #143252;
+}
+
+.btn-success {
+  --bs-btn-color: #ffffff;
+  --bs-btn-bg: #198754;
+  --bs-btn-border-color: #198754;
+  --bs-btn-hover-color: #ffffff;
+  --bs-btn-hover-bg: rgb(21.25, 114.75, 71.4);
+  --bs-btn-hover-border-color: rgb(20, 108, 67.2);
+  --bs-btn-focus-shadow-rgb: 60, 153, 110;
+  --bs-btn-active-color: #ffffff;
+  --bs-btn-active-bg: rgb(20, 108, 67.2);
+  --bs-btn-active-border-color: rgb(18.75, 101.25, 63);
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #ffffff;
+  --bs-btn-disabled-bg: #198754;
+  --bs-btn-disabled-border-color: #198754;
+}
+
+.btn-info {
+  --bs-btn-color: #000000;
+  --bs-btn-bg: #0dcaf0;
+  --bs-btn-border-color: #0dcaf0;
+  --bs-btn-hover-color: #000000;
+  --bs-btn-hover-bg: rgb(49.3, 209.95, 242.25);
+  --bs-btn-hover-border-color: rgb(37.2, 207.3, 241.5);
+  --bs-btn-focus-shadow-rgb: 11, 172, 204;
+  --bs-btn-active-color: #000000;
+  --bs-btn-active-bg: rgb(61.4, 212.6, 243);
+  --bs-btn-active-border-color: rgb(37.2, 207.3, 241.5);
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #000000;
+  --bs-btn-disabled-bg: #0dcaf0;
+  --bs-btn-disabled-border-color: #0dcaf0;
+}
+
+.btn-warning {
+  --bs-btn-color: #000000;
+  --bs-btn-bg: #ffc107;
+  --bs-btn-border-color: #ffc107;
+  --bs-btn-hover-color: #000000;
+  --bs-btn-hover-bg: rgb(255, 202.3, 44.2);
+  --bs-btn-hover-border-color: rgb(255, 199.2, 31.8);
+  --bs-btn-focus-shadow-rgb: 217, 164, 6;
+  --bs-btn-active-color: #000000;
+  --bs-btn-active-bg: rgb(255, 205.4, 56.6);
+  --bs-btn-active-border-color: rgb(255, 199.2, 31.8);
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #000000;
+  --bs-btn-disabled-bg: #ffc107;
+  --bs-btn-disabled-border-color: #ffc107;
+}
+
+.btn-danger {
+  --bs-btn-color: #ffffff;
+  --bs-btn-bg: #d0181e;
+  --bs-btn-border-color: #d0181e;
+  --bs-btn-hover-color: #ffffff;
+  --bs-btn-hover-bg: rgb(176.8, 20.4, 25.5);
+  --bs-btn-hover-border-color: rgb(166.4, 19.2, 24);
+  --bs-btn-focus-shadow-rgb: 215, 59, 64;
+  --bs-btn-active-color: #ffffff;
+  --bs-btn-active-bg: rgb(166.4, 19.2, 24);
+  --bs-btn-active-border-color: rgb(156, 18, 22.5);
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #ffffff;
+  --bs-btn-disabled-bg: #d0181e;
+  --bs-btn-disabled-border-color: #d0181e;
+}
+
+.btn-light {
+  --bs-btn-color: #000000;
+  --bs-btn-bg: #f8f9fa;
+  --bs-btn-border-color: #f8f9fa;
+  --bs-btn-hover-color: #000000;
+  --bs-btn-hover-bg: rgb(210.8, 211.65, 212.5);
+  --bs-btn-hover-border-color: rgb(198.4, 199.2, 200);
+  --bs-btn-focus-shadow-rgb: 211, 212, 213;
+  --bs-btn-active-color: #000000;
+  --bs-btn-active-bg: rgb(198.4, 199.2, 200);
+  --bs-btn-active-border-color: rgb(186, 186.75, 187.5);
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #000000;
+  --bs-btn-disabled-bg: #f8f9fa;
+  --bs-btn-disabled-border-color: #f8f9fa;
+}
+
+.btn-dark {
+  --bs-btn-color: #ffffff;
+  --bs-btn-bg: #212529;
+  --bs-btn-border-color: #212529;
+  --bs-btn-hover-color: #ffffff;
+  --bs-btn-hover-bg: rgb(66.3, 69.7, 73.1);
+  --bs-btn-hover-border-color: rgb(55.2, 58.8, 62.4);
+  --bs-btn-focus-shadow-rgb: 66, 70, 73;
+  --bs-btn-active-color: #ffffff;
+  --bs-btn-active-bg: rgb(77.4, 80.6, 83.8);
+  --bs-btn-active-border-color: rgb(55.2, 58.8, 62.4);
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #ffffff;
+  --bs-btn-disabled-bg: #212529;
+  --bs-btn-disabled-border-color: #212529;
+}
+
+.btn-outline-primary {
+  --bs-btn-color: #0A1929;
+  --bs-btn-border-color: #0A1929;
+  --bs-btn-hover-color: #ffffff;
+  --bs-btn-hover-bg: #0A1929;
+  --bs-btn-hover-border-color: #0A1929;
+  --bs-btn-focus-shadow-rgb: 10, 25, 41;
+  --bs-btn-active-color: #ffffff;
+  --bs-btn-active-bg: #0A1929;
+  --bs-btn-active-border-color: #0A1929;
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #0A1929;
+  --bs-btn-disabled-bg: transparent;
+  --bs-btn-disabled-border-color: #0A1929;
+  --bs-gradient: none;
+}
+
+.btn-outline-secondary {
+  --bs-btn-color: #143252;
+  --bs-btn-border-color: #143252;
+  --bs-btn-hover-color: #ffffff;
+  --bs-btn-hover-bg: #143252;
+  --bs-btn-hover-border-color: #143252;
+  --bs-btn-focus-shadow-rgb: 20, 50, 82;
+  --bs-btn-active-color: #ffffff;
+  --bs-btn-active-bg: #143252;
+  --bs-btn-active-border-color: #143252;
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #143252;
+  --bs-btn-disabled-bg: transparent;
+  --bs-btn-disabled-border-color: #143252;
+  --bs-gradient: none;
+}
+
+.btn-outline-success {
+  --bs-btn-color: #198754;
+  --bs-btn-border-color: #198754;
+  --bs-btn-hover-color: #ffffff;
+  --bs-btn-hover-bg: #198754;
+  --bs-btn-hover-border-color: #198754;
+  --bs-btn-focus-shadow-rgb: 25, 135, 84;
+  --bs-btn-active-color: #ffffff;
+  --bs-btn-active-bg: #198754;
+  --bs-btn-active-border-color: #198754;
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #198754;
+  --bs-btn-disabled-bg: transparent;
+  --bs-btn-disabled-border-color: #198754;
+  --bs-gradient: none;
+}
+
+.btn-outline-info {
+  --bs-btn-color: #0dcaf0;
+  --bs-btn-border-color: #0dcaf0;
+  --bs-btn-hover-color: #000000;
+  --bs-btn-hover-bg: #0dcaf0;
+  --bs-btn-hover-border-color: #0dcaf0;
+  --bs-btn-focus-shadow-rgb: 13, 202, 240;
+  --bs-btn-active-color: #000000;
+  --bs-btn-active-bg: #0dcaf0;
+  --bs-btn-active-border-color: #0dcaf0;
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #0dcaf0;
+  --bs-btn-disabled-bg: transparent;
+  --bs-btn-disabled-border-color: #0dcaf0;
+  --bs-gradient: none;
+}
+
+.btn-outline-warning {
+  --bs-btn-color: #ffc107;
+  --bs-btn-border-color: #ffc107;
+  --bs-btn-hover-color: #000000;
+  --bs-btn-hover-bg: #ffc107;
+  --bs-btn-hover-border-color: #ffc107;
+  --bs-btn-focus-shadow-rgb: 255, 193, 7;
+  --bs-btn-active-color: #000000;
+  --bs-btn-active-bg: #ffc107;
+  --bs-btn-active-border-color: #ffc107;
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #ffc107;
+  --bs-btn-disabled-bg: transparent;
+  --bs-btn-disabled-border-color: #ffc107;
+  --bs-gradient: none;
+}
+
+.btn-outline-danger {
+  --bs-btn-color: #d0181e;
+  --bs-btn-border-color: #d0181e;
+  --bs-btn-hover-color: #ffffff;
+  --bs-btn-hover-bg: #d0181e;
+  --bs-btn-hover-border-color: #d0181e;
+  --bs-btn-focus-shadow-rgb: 208, 24, 30;
+  --bs-btn-active-color: #ffffff;
+  --bs-btn-active-bg: #d0181e;
+  --bs-btn-active-border-color: #d0181e;
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #d0181e;
+  --bs-btn-disabled-bg: transparent;
+  --bs-btn-disabled-border-color: #d0181e;
+  --bs-gradient: none;
+}
+
+.btn-outline-light {
+  --bs-btn-color: #f8f9fa;
+  --bs-btn-border-color: #f8f9fa;
+  --bs-btn-hover-color: #000000;
+  --bs-btn-hover-bg: #f8f9fa;
+  --bs-btn-hover-border-color: #f8f9fa;
+  --bs-btn-focus-shadow-rgb: 248, 249, 250;
+  --bs-btn-active-color: #000000;
+  --bs-btn-active-bg: #f8f9fa;
+  --bs-btn-active-border-color: #f8f9fa;
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #f8f9fa;
+  --bs-btn-disabled-bg: transparent;
+  --bs-btn-disabled-border-color: #f8f9fa;
+  --bs-gradient: none;
+}
+
+.btn-outline-dark {
+  --bs-btn-color: #212529;
+  --bs-btn-border-color: #212529;
+  --bs-btn-hover-color: #ffffff;
+  --bs-btn-hover-bg: #212529;
+  --bs-btn-hover-border-color: #212529;
+  --bs-btn-focus-shadow-rgb: 33, 37, 41;
+  --bs-btn-active-color: #ffffff;
+  --bs-btn-active-bg: #212529;
+  --bs-btn-active-border-color: #212529;
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #212529;
+  --bs-btn-disabled-bg: transparent;
+  --bs-btn-disabled-border-color: #212529;
+  --bs-gradient: none;
+}
+
+.btn-link {
+  --bs-btn-font-weight: 400;
+  --bs-btn-color: var(--bs-link-color);
+  --bs-btn-bg: transparent;
+  --bs-btn-border-color: transparent;
+  --bs-btn-hover-color: var(--bs-link-hover-color);
+  --bs-btn-hover-border-color: transparent;
+  --bs-btn-active-color: var(--bs-link-hover-color);
+  --bs-btn-active-border-color: transparent;
+  --bs-btn-disabled-color: #6c757d;
+  --bs-btn-disabled-border-color: transparent;
+  --bs-btn-box-shadow: 0 0 0 #000;
+  --bs-btn-focus-shadow-rgb: 47, 60, 73;
+  text-decoration: underline;
+}
+.btn-link:focus-visible {
+  color: var(--bs-btn-color);
+}
+.btn-link:hover {
+  color: var(--bs-btn-hover-color);
+}
+
+.btn-lg, .btn-group-lg > .btn {
+  --bs-btn-padding-y: 0.5rem;
+  --bs-btn-padding-x: 1rem;
+  --bs-btn-font-size: 1.25rem;
+  --bs-btn-border-radius: var(--bs-border-radius-lg);
+}
+
+.btn-sm, .btn-group-sm > .btn {
+  --bs-btn-padding-y: 0.25rem;
+  --bs-btn-padding-x: 0.5rem;
+  --bs-btn-font-size: 0.875rem;
+  --bs-btn-border-radius: var(--bs-border-radius-sm);
+}
+
+.fade {
+  transition: opacity 0.15s linear;
+}
+@media (prefers-reduced-motion: reduce) {
+  .fade {
+    transition: none;
+  }
+}
+.fade:not(.show) {
+  opacity: 0;
+}
+
+.collapse:not(.show) {
+  display: none;
+}
+
+.collapsing {
+  height: 0;
+  overflow: hidden;
+  transition: height 0.35s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  .collapsing {
+    transition: none;
+  }
+}
+.collapsing.collapse-horizontal {
+  width: 0;
+  height: auto;
+  transition: width 0.35s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  .collapsing.collapse-horizontal {
+    transition: none;
+  }
+}
+
+.dropup,
+.dropend,
+.dropdown,
+.dropstart,
+.dropup-center,
+.dropdown-center {
+  position: relative;
+}
+
+.dropdown-toggle {
+  white-space: nowrap;
+}
+.dropdown-toggle::after {
+  display: inline-block;
+  margin-left: 0.255em;
+  vertical-align: 0.255em;
+  content: "";
+  border-top: 0.3em solid;
+  border-right: 0.3em solid transparent;
+  border-bottom: 0;
+  border-left: 0.3em solid transparent;
+}
+.dropdown-toggle:empty::after {
+  margin-left: 0;
+}
+
+.dropdown-menu {
+  --bs-dropdown-zindex: 1000;
+  --bs-dropdown-min-width: 10rem;
+  --bs-dropdown-padding-x: 0;
+  --bs-dropdown-padding-y: 0.5rem;
+  --bs-dropdown-spacer: 0.125rem;
+  --bs-dropdown-font-size: 1rem;
+  --bs-dropdown-color: var(--bs-body-color);
+  --bs-dropdown-bg: var(--bs-body-bg);
+  --bs-dropdown-border-color: var(--bs-border-color-translucent);
+  --bs-dropdown-border-radius: var(--bs-border-radius);
+  --bs-dropdown-border-width: var(--bs-border-width);
+  --bs-dropdown-inner-border-radius: calc(var(--bs-border-radius) - var(--bs-border-width));
+  --bs-dropdown-divider-bg: var(--bs-border-color-translucent);
+  --bs-dropdown-divider-margin-y: 0.5rem;
+  --bs-dropdown-box-shadow: var(--bs-box-shadow);
+  --bs-dropdown-link-color: var(--bs-body-color);
+  --bs-dropdown-link-hover-color: var(--bs-body-color);
+  --bs-dropdown-link-hover-bg: var(--bs-tertiary-bg);
+  --bs-dropdown-link-active-color: #ffffff;
+  --bs-dropdown-link-active-bg: #0A1929;
+  --bs-dropdown-link-disabled-color: var(--bs-tertiary-color);
+  --bs-dropdown-item-padding-x: 1rem;
+  --bs-dropdown-item-padding-y: 0.25rem;
+  --bs-dropdown-header-color: #6c757d;
+  --bs-dropdown-header-padding-x: 1rem;
+  --bs-dropdown-header-padding-y: 0.5rem;
+  position: absolute;
+  z-index: var(--bs-dropdown-zindex);
+  display: none;
+  min-width: var(--bs-dropdown-min-width);
+  padding: var(--bs-dropdown-padding-y) var(--bs-dropdown-padding-x);
+  margin: 0;
+  font-size: var(--bs-dropdown-font-size);
+  color: var(--bs-dropdown-color);
+  text-align: left;
+  list-style: none;
+  background-color: var(--bs-dropdown-bg);
+  background-clip: padding-box;
+  border: var(--bs-dropdown-border-width) solid var(--bs-dropdown-border-color);
+  border-radius: var(--bs-dropdown-border-radius);
+}
+.dropdown-menu[data-bs-popper] {
+  top: 100%;
+  left: 0;
+  margin-top: var(--bs-dropdown-spacer);
+}
+
+.dropdown-menu-start {
+  --bs-position: start;
+}
+.dropdown-menu-start[data-bs-popper] {
+  right: auto;
+  left: 0;
+}
+
+.dropdown-menu-end {
+  --bs-position: end;
+}
+.dropdown-menu-end[data-bs-popper] {
+  right: 0;
+  left: auto;
+}
+
+@media (min-width: 576px) {
+  .dropdown-menu-sm-start {
+    --bs-position: start;
+  }
+  .dropdown-menu-sm-start[data-bs-popper] {
+    right: auto;
+    left: 0;
+  }
+  .dropdown-menu-sm-end {
+    --bs-position: end;
+  }
+  .dropdown-menu-sm-end[data-bs-popper] {
+    right: 0;
+    left: auto;
+  }
+}
+@media (min-width: 768px) {
+  .dropdown-menu-md-start {
+    --bs-position: start;
+  }
+  .dropdown-menu-md-start[data-bs-popper] {
+    right: auto;
+    left: 0;
+  }
+  .dropdown-menu-md-end {
+    --bs-position: end;
+  }
+  .dropdown-menu-md-end[data-bs-popper] {
+    right: 0;
+    left: auto;
+  }
+}
+@media (min-width: 992px) {
+  .dropdown-menu-lg-start {
+    --bs-position: start;
+  }
+  .dropdown-menu-lg-start[data-bs-popper] {
+    right: auto;
+    left: 0;
+  }
+  .dropdown-menu-lg-end {
+    --bs-position: end;
+  }
+  .dropdown-menu-lg-end[data-bs-popper] {
+    right: 0;
+    left: auto;
+  }
+}
+@media (min-width: 1200px) {
+  .dropdown-menu-xl-start {
+    --bs-position: start;
+  }
+  .dropdown-menu-xl-start[data-bs-popper] {
+    right: auto;
+    left: 0;
+  }
+  .dropdown-menu-xl-end {
+    --bs-position: end;
+  }
+  .dropdown-menu-xl-end[data-bs-popper] {
+    right: 0;
+    left: auto;
+  }
+}
+@media (min-width: 1400px) {
+  .dropdown-menu-xxl-start {
+    --bs-position: start;
+  }
+  .dropdown-menu-xxl-start[data-bs-popper] {
+    right: auto;
+    left: 0;
+  }
+  .dropdown-menu-xxl-end {
+    --bs-position: end;
+  }
+  .dropdown-menu-xxl-end[data-bs-popper] {
+    right: 0;
+    left: auto;
+  }
+}
+.dropup .dropdown-menu[data-bs-popper] {
+  top: auto;
+  bottom: 100%;
+  margin-top: 0;
+  margin-bottom: var(--bs-dropdown-spacer);
+}
+.dropup .dropdown-toggle::after {
+  display: inline-block;
+  margin-left: 0.255em;
+  vertical-align: 0.255em;
+  content: "";
+  border-top: 0;
+  border-right: 0.3em solid transparent;
+  border-bottom: 0.3em solid;
+  border-left: 0.3em solid transparent;
+}
+.dropup .dropdown-toggle:empty::after {
+  margin-left: 0;
+}
+
+.dropend .dropdown-menu[data-bs-popper] {
+  top: 0;
+  right: auto;
+  left: 100%;
+  margin-top: 0;
+  margin-left: var(--bs-dropdown-spacer);
+}
+.dropend .dropdown-toggle::after {
+  display: inline-block;
+  margin-left: 0.255em;
+  vertical-align: 0.255em;
+  content: "";
+  border-top: 0.3em solid transparent;
+  border-right: 0;
+  border-bottom: 0.3em solid transparent;
+  border-left: 0.3em solid;
+}
+.dropend .dropdown-toggle:empty::after {
+  margin-left: 0;
+}
+.dropend .dropdown-toggle::after {
+  vertical-align: 0;
+}
+
+.dropstart .dropdown-menu[data-bs-popper] {
+  top: 0;
+  right: 100%;
+  left: auto;
+  margin-top: 0;
+  margin-right: var(--bs-dropdown-spacer);
+}
+.dropstart .dropdown-toggle::after {
+  display: inline-block;
+  margin-left: 0.255em;
+  vertical-align: 0.255em;
+  content: "";
+}
+.dropstart .dropdown-toggle::after {
+  display: none;
+}
+.dropstart .dropdown-toggle::before {
+  display: inline-block;
+  margin-right: 0.255em;
+  vertical-align: 0.255em;
+  content: "";
+  border-top: 0.3em solid transparent;
+  border-right: 0.3em solid;
+  border-bottom: 0.3em solid transparent;
+}
+.dropstart .dropdown-toggle:empty::after {
+  margin-left: 0;
+}
+.dropstart .dropdown-toggle::before {
+  vertical-align: 0;
+}
+
+.dropdown-divider {
+  height: 0;
+  margin: var(--bs-dropdown-divider-margin-y) 0;
+  overflow: hidden;
+  border-top: 1px solid var(--bs-dropdown-divider-bg);
+  opacity: 1;
+}
+
+.dropdown-item {
+  display: block;
+  width: 100%;
+  padding: var(--bs-dropdown-item-padding-y) var(--bs-dropdown-item-padding-x);
+  clear: both;
+  font-weight: 400;
+  color: var(--bs-dropdown-link-color);
+  text-align: inherit;
+  text-decoration: none;
+  white-space: nowrap;
+  background-color: transparent;
+  border: 0;
+  border-radius: var(--bs-dropdown-item-border-radius, 0);
+}
+.dropdown-item:hover, .dropdown-item:focus {
+  color: var(--bs-dropdown-link-hover-color);
+  background-color: var(--bs-dropdown-link-hover-bg);
+}
+.dropdown-item.active, .dropdown-item:active {
+  color: var(--bs-dropdown-link-active-color);
+  text-decoration: none;
+  background-color: var(--bs-dropdown-link-active-bg);
+}
+.dropdown-item.disabled, .dropdown-item:disabled {
+  color: var(--bs-dropdown-link-disabled-color);
+  pointer-events: none;
+  background-color: transparent;
+}
+
+.dropdown-menu.show {
+  display: block;
+}
+
+.dropdown-header {
+  display: block;
+  padding: var(--bs-dropdown-header-padding-y) var(--bs-dropdown-header-padding-x);
+  margin-bottom: 0;
+  font-size: 0.875rem;
+  color: var(--bs-dropdown-header-color);
+  white-space: nowrap;
+}
+
+.dropdown-item-text {
+  display: block;
+  padding: var(--bs-dropdown-item-padding-y) var(--bs-dropdown-item-padding-x);
+  color: var(--bs-dropdown-link-color);
+}
+
+.dropdown-menu-dark {
+  --bs-dropdown-color: #dee2e6;
+  --bs-dropdown-bg: #343a40;
+  --bs-dropdown-border-color: var(--bs-border-color-translucent);
+  --bs-dropdown-box-shadow: ;
+  --bs-dropdown-link-color: #dee2e6;
+  --bs-dropdown-link-hover-color: #ffffff;
+  --bs-dropdown-divider-bg: var(--bs-border-color-translucent);
+  --bs-dropdown-link-hover-bg: rgba(255, 255, 255, 0.15);
+  --bs-dropdown-link-active-color: #ffffff;
+  --bs-dropdown-link-active-bg: #0A1929;
+  --bs-dropdown-link-disabled-color: #adb5bd;
+  --bs-dropdown-header-color: #adb5bd;
+}
+
+.btn-group,
+.btn-group-vertical {
+  position: relative;
+  display: inline-flex;
+  vertical-align: middle;
+}
+.btn-group > .btn,
+.btn-group-vertical > .btn {
+  position: relative;
+  flex: 1 1 auto;
+}
+.btn-group > .btn-check:checked + .btn,
+.btn-group > .btn-check:focus + .btn,
+.btn-group > .btn:hover,
+.btn-group > .btn:focus,
+.btn-group > .btn:active,
+.btn-group > .btn.active,
+.btn-group-vertical > .btn-check:checked + .btn,
+.btn-group-vertical > .btn-check:focus + .btn,
+.btn-group-vertical > .btn:hover,
+.btn-group-vertical > .btn:focus,
+.btn-group-vertical > .btn:active,
+.btn-group-vertical > .btn.active {
+  z-index: 1;
+}
+
+.btn-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+.btn-toolbar .input-group {
+  width: auto;
+}
+
+.btn-group {
+  border-radius: var(--bs-border-radius);
+}
+.btn-group > :not(.btn-check:first-child) + .btn,
+.btn-group > .btn-group:not(:first-child) {
+  margin-left: calc(-1 * var(--bs-border-width));
+}
+.btn-group > .btn:not(:last-child):not(.dropdown-toggle),
+.btn-group > .btn.dropdown-toggle-split:first-child,
+.btn-group > .btn-group:not(:last-child) > .btn {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.btn-group > .btn:nth-child(n+3),
+.btn-group > :not(.btn-check) + .btn,
+.btn-group > .btn-group:not(:first-child) > .btn {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.dropdown-toggle-split {
+  padding-right: 0.5625rem;
+  padding-left: 0.5625rem;
+}
+.dropdown-toggle-split::after, .dropup .dropdown-toggle-split::after, .dropend .dropdown-toggle-split::after {
+  margin-left: 0;
+}
+.dropstart .dropdown-toggle-split::before {
+  margin-right: 0;
+}
+
+.btn-sm + .dropdown-toggle-split, .btn-group-sm > .btn + .dropdown-toggle-split {
+  padding-right: 0.375rem;
+  padding-left: 0.375rem;
+}
+
+.btn-lg + .dropdown-toggle-split, .btn-group-lg > .btn + .dropdown-toggle-split {
+  padding-right: 0.75rem;
+  padding-left: 0.75rem;
+}
+
+.btn-group-vertical {
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+}
+.btn-group-vertical > .btn,
+.btn-group-vertical > .btn-group {
+  width: 100%;
+}
+.btn-group-vertical > .btn:not(:first-child),
+.btn-group-vertical > .btn-group:not(:first-child) {
+  margin-top: calc(-1 * var(--bs-border-width));
+}
+.btn-group-vertical > .btn:not(:last-child):not(.dropdown-toggle),
+.btn-group-vertical > .btn-group:not(:last-child) > .btn {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.btn-group-vertical > .btn:nth-child(n+3),
+.btn-group-vertical > :not(.btn-check) + .btn,
+.btn-group-vertical > .btn-group:not(:first-child) > .btn {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.nav {
+  --bs-nav-link-padding-x: 1rem;
+  --bs-nav-link-padding-y: 0.5rem;
+  --bs-nav-link-font-weight: ;
+  --bs-nav-link-color: var(--bs-link-color);
+  --bs-nav-link-hover-color: var(--bs-link-hover-color);
+  --bs-nav-link-disabled-color: var(--bs-secondary-color);
+  display: flex;
+  flex-wrap: wrap;
+  padding-left: 0;
+  margin-bottom: 0;
+  list-style: none;
+}
+
+.nav-link {
+  display: block;
+  padding: var(--bs-nav-link-padding-y) var(--bs-nav-link-padding-x);
+  font-size: var(--bs-nav-link-font-size);
+  font-weight: var(--bs-nav-link-font-weight);
+  color: var(--bs-nav-link-color);
+  text-decoration: none;
+  background: none;
+  border: 0;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .nav-link {
+    transition: none;
+  }
+}
+.nav-link:hover, .nav-link:focus {
+  color: var(--bs-nav-link-hover-color);
+}
+.nav-link:focus-visible {
+  outline: 0;
+  box-shadow: 0 0 0 0.25rem rgba(10, 25, 41, 0.25);
+}
+.nav-link.disabled, .nav-link:disabled {
+  color: var(--bs-nav-link-disabled-color);
+  pointer-events: none;
+  cursor: default;
+}
+
+.nav-tabs {
+  --bs-nav-tabs-border-width: var(--bs-border-width);
+  --bs-nav-tabs-border-color: var(--bs-border-color);
+  --bs-nav-tabs-border-radius: var(--bs-border-radius);
+  --bs-nav-tabs-link-hover-border-color: var(--bs-secondary-bg) var(--bs-secondary-bg) var(--bs-border-color);
+  --bs-nav-tabs-link-active-color: var(--bs-emphasis-color);
+  --bs-nav-tabs-link-active-bg: var(--bs-body-bg);
+  --bs-nav-tabs-link-active-border-color: var(--bs-border-color) var(--bs-border-color) var(--bs-body-bg);
+  border-bottom: var(--bs-nav-tabs-border-width) solid var(--bs-nav-tabs-border-color);
+}
+.nav-tabs .nav-link {
+  margin-bottom: calc(-1 * var(--bs-nav-tabs-border-width));
+  border: var(--bs-nav-tabs-border-width) solid transparent;
+  border-top-left-radius: var(--bs-nav-tabs-border-radius);
+  border-top-right-radius: var(--bs-nav-tabs-border-radius);
+}
+.nav-tabs .nav-link:hover, .nav-tabs .nav-link:focus {
+  isolation: isolate;
+  border-color: var(--bs-nav-tabs-link-hover-border-color);
+}
+.nav-tabs .nav-link.active,
+.nav-tabs .nav-item.show .nav-link {
+  color: var(--bs-nav-tabs-link-active-color);
+  background-color: var(--bs-nav-tabs-link-active-bg);
+  border-color: var(--bs-nav-tabs-link-active-border-color);
+}
+.nav-tabs .dropdown-menu {
+  margin-top: calc(-1 * var(--bs-nav-tabs-border-width));
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.nav-pills {
+  --bs-nav-pills-border-radius: var(--bs-border-radius);
+  --bs-nav-pills-link-active-color: #ffffff;
+  --bs-nav-pills-link-active-bg: #0A1929;
+}
+.nav-pills .nav-link {
+  border-radius: var(--bs-nav-pills-border-radius);
+}
+.nav-pills .nav-link.active,
+.nav-pills .show > .nav-link {
+  color: var(--bs-nav-pills-link-active-color);
+  background-color: var(--bs-nav-pills-link-active-bg);
+}
+
+.nav-underline {
+  --bs-nav-underline-gap: 1rem;
+  --bs-nav-underline-border-width: 0.125rem;
+  --bs-nav-underline-link-active-color: var(--bs-emphasis-color);
+  gap: var(--bs-nav-underline-gap);
+}
+.nav-underline .nav-link {
+  padding-right: 0;
+  padding-left: 0;
+  border-bottom: var(--bs-nav-underline-border-width) solid transparent;
+}
+.nav-underline .nav-link:hover, .nav-underline .nav-link:focus {
+  border-bottom-color: currentcolor;
+}
+.nav-underline .nav-link.active,
+.nav-underline .show > .nav-link {
+  font-weight: 700;
+  color: var(--bs-nav-underline-link-active-color);
+  border-bottom-color: currentcolor;
+}
+
+.nav-fill > .nav-link,
+.nav-fill .nav-item {
+  flex: 1 1 auto;
+  text-align: center;
+}
+
+.nav-justified > .nav-link,
+.nav-justified .nav-item {
+  flex-grow: 1;
+  flex-basis: 0;
+  text-align: center;
+}
+
+.nav-fill .nav-item .nav-link,
+.nav-justified .nav-item .nav-link {
+  width: 100%;
+}
+
+.tab-content > .tab-pane {
+  display: none;
+}
+.tab-content > .active {
+  display: block;
+}
+
+.navbar {
+  --bs-navbar-padding-x: 0;
+  --bs-navbar-padding-y: 0.5rem;
+  --bs-navbar-color: rgba(var(--bs-emphasis-color-rgb), 0.65);
+  --bs-navbar-hover-color: rgba(var(--bs-emphasis-color-rgb), 0.8);
+  --bs-navbar-disabled-color: rgba(var(--bs-emphasis-color-rgb), 0.3);
+  --bs-navbar-active-color: rgba(var(--bs-emphasis-color-rgb), 1);
+  --bs-navbar-brand-padding-y: 0.3125rem;
+  --bs-navbar-brand-margin-end: 1rem;
+  --bs-navbar-brand-font-size: 1.25rem;
+  --bs-navbar-brand-color: rgba(var(--bs-emphasis-color-rgb), 1);
+  --bs-navbar-brand-hover-color: rgba(var(--bs-emphasis-color-rgb), 1);
+  --bs-navbar-nav-link-padding-x: 0.5rem;
+  --bs-navbar-toggler-padding-y: 0.25rem;
+  --bs-navbar-toggler-padding-x: 0.75rem;
+  --bs-navbar-toggler-font-size: 1.25rem;
+  --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%2833, 37, 41, 0.75%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+  --bs-navbar-toggler-border-color: rgba(var(--bs-emphasis-color-rgb), 0.15);
+  --bs-navbar-toggler-border-radius: var(--bs-border-radius);
+  --bs-navbar-toggler-focus-width: 0.25rem;
+  --bs-navbar-toggler-transition: box-shadow 0.15s ease-in-out;
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--bs-navbar-padding-y) var(--bs-navbar-padding-x);
+}
+.navbar > .container,
+.navbar > .container-fluid,
+.navbar > .container-sm,
+.navbar > .container-md,
+.navbar > .container-lg,
+.navbar > .container-xl,
+.navbar > .container-xxl {
+  display: flex;
+  flex-wrap: inherit;
+  align-items: center;
+  justify-content: space-between;
+}
+.navbar-brand {
+  padding-top: var(--bs-navbar-brand-padding-y);
+  padding-bottom: var(--bs-navbar-brand-padding-y);
+  margin-right: var(--bs-navbar-brand-margin-end);
+  font-size: var(--bs-navbar-brand-font-size);
+  color: var(--bs-navbar-brand-color);
+  text-decoration: none;
+  white-space: nowrap;
+}
+.navbar-brand:hover, .navbar-brand:focus {
+  color: var(--bs-navbar-brand-hover-color);
+}
+
+.navbar-nav {
+  --bs-nav-link-padding-x: 0;
+  --bs-nav-link-padding-y: 0.5rem;
+  --bs-nav-link-font-weight: ;
+  --bs-nav-link-color: var(--bs-navbar-color);
+  --bs-nav-link-hover-color: var(--bs-navbar-hover-color);
+  --bs-nav-link-disabled-color: var(--bs-navbar-disabled-color);
+  display: flex;
+  flex-direction: column;
+  padding-left: 0;
+  margin-bottom: 0;
+  list-style: none;
+}
+.navbar-nav .nav-link.active, .navbar-nav .nav-link.show {
+  color: var(--bs-navbar-active-color);
+}
+.navbar-nav .dropdown-menu {
+  position: static;
+}
+
+.navbar-text {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  color: var(--bs-navbar-color);
+}
+.navbar-text a,
+.navbar-text a:hover,
+.navbar-text a:focus {
+  color: var(--bs-navbar-active-color);
+}
+
+.navbar-collapse {
+  flex-grow: 1;
+  flex-basis: 100%;
+  align-items: center;
+}
+
+.navbar-toggler {
+  padding: var(--bs-navbar-toggler-padding-y) var(--bs-navbar-toggler-padding-x);
+  font-size: var(--bs-navbar-toggler-font-size);
+  line-height: 1;
+  color: var(--bs-navbar-color);
+  background-color: transparent;
+  border: var(--bs-border-width) solid var(--bs-navbar-toggler-border-color);
+  border-radius: var(--bs-navbar-toggler-border-radius);
+  transition: var(--bs-navbar-toggler-transition);
+}
+@media (prefers-reduced-motion: reduce) {
+  .navbar-toggler {
+    transition: none;
+  }
+}
+.navbar-toggler:hover {
+  text-decoration: none;
+}
+.navbar-toggler:focus {
+  text-decoration: none;
+  outline: 0;
+  box-shadow: 0 0 0 var(--bs-navbar-toggler-focus-width);
+}
+
+.navbar-toggler-icon {
+  display: inline-block;
+  width: 1.5em;
+  height: 1.5em;
+  vertical-align: middle;
+  background-image: var(--bs-navbar-toggler-icon-bg);
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 100%;
+}
+
+.navbar-nav-scroll {
+  max-height: var(--bs-scroll-height, 75vh);
+  overflow-y: auto;
+}
+
+@media (min-width: 576px) {
+  .navbar-expand-sm {
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+  }
+  .navbar-expand-sm .navbar-nav {
+    flex-direction: row;
+  }
+  .navbar-expand-sm .navbar-nav .dropdown-menu {
+    position: absolute;
+  }
+  .navbar-expand-sm .navbar-nav .nav-link {
+    padding-right: var(--bs-navbar-nav-link-padding-x);
+    padding-left: var(--bs-navbar-nav-link-padding-x);
+  }
+  .navbar-expand-sm .navbar-nav-scroll {
+    overflow: visible;
+  }
+  .navbar-expand-sm .navbar-collapse {
+    display: flex !important;
+    flex-basis: auto;
+  }
+  .navbar-expand-sm .navbar-toggler {
+    display: none;
+  }
+  .navbar-expand-sm .offcanvas {
+    position: static;
+    z-index: auto;
+    flex-grow: 1;
+    width: auto !important;
+    height: auto !important;
+    visibility: visible !important;
+    background-color: transparent !important;
+    border: 0 !important;
+    transform: none !important;
+    transition: none;
+  }
+  .navbar-expand-sm .offcanvas .offcanvas-header {
+    display: none;
+  }
+  .navbar-expand-sm .offcanvas .offcanvas-body {
+    display: flex;
+    flex-grow: 0;
+    padding: 0;
+    overflow-y: visible;
+  }
+}
+@media (min-width: 768px) {
+  .navbar-expand-md {
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+  }
+  .navbar-expand-md .navbar-nav {
+    flex-direction: row;
+  }
+  .navbar-expand-md .navbar-nav .dropdown-menu {
+    position: absolute;
+  }
+  .navbar-expand-md .navbar-nav .nav-link {
+    padding-right: var(--bs-navbar-nav-link-padding-x);
+    padding-left: var(--bs-navbar-nav-link-padding-x);
+  }
+  .navbar-expand-md .navbar-nav-scroll {
+    overflow: visible;
+  }
+  .navbar-expand-md .navbar-collapse {
+    display: flex !important;
+    flex-basis: auto;
+  }
+  .navbar-expand-md .navbar-toggler {
+    display: none;
+  }
+  .navbar-expand-md .offcanvas {
+    position: static;
+    z-index: auto;
+    flex-grow: 1;
+    width: auto !important;
+    height: auto !important;
+    visibility: visible !important;
+    background-color: transparent !important;
+    border: 0 !important;
+    transform: none !important;
+    transition: none;
+  }
+  .navbar-expand-md .offcanvas .offcanvas-header {
+    display: none;
+  }
+  .navbar-expand-md .offcanvas .offcanvas-body {
+    display: flex;
+    flex-grow: 0;
+    padding: 0;
+    overflow-y: visible;
+  }
+}
+@media (min-width: 992px) {
+  .navbar-expand-lg {
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+  }
+  .navbar-expand-lg .navbar-nav {
+    flex-direction: row;
+  }
+  .navbar-expand-lg .navbar-nav .dropdown-menu {
+    position: absolute;
+  }
+  .navbar-expand-lg .navbar-nav .nav-link {
+    padding-right: var(--bs-navbar-nav-link-padding-x);
+    padding-left: var(--bs-navbar-nav-link-padding-x);
+  }
+  .navbar-expand-lg .navbar-nav-scroll {
+    overflow: visible;
+  }
+  .navbar-expand-lg .navbar-collapse {
+    display: flex !important;
+    flex-basis: auto;
+  }
+  .navbar-expand-lg .navbar-toggler {
+    display: none;
+  }
+  .navbar-expand-lg .offcanvas {
+    position: static;
+    z-index: auto;
+    flex-grow: 1;
+    width: auto !important;
+    height: auto !important;
+    visibility: visible !important;
+    background-color: transparent !important;
+    border: 0 !important;
+    transform: none !important;
+    transition: none;
+  }
+  .navbar-expand-lg .offcanvas .offcanvas-header {
+    display: none;
+  }
+  .navbar-expand-lg .offcanvas .offcanvas-body {
+    display: flex;
+    flex-grow: 0;
+    padding: 0;
+    overflow-y: visible;
+  }
+}
+@media (min-width: 1200px) {
+  .navbar-expand-xl {
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+  }
+  .navbar-expand-xl .navbar-nav {
+    flex-direction: row;
+  }
+  .navbar-expand-xl .navbar-nav .dropdown-menu {
+    position: absolute;
+  }
+  .navbar-expand-xl .navbar-nav .nav-link {
+    padding-right: var(--bs-navbar-nav-link-padding-x);
+    padding-left: var(--bs-navbar-nav-link-padding-x);
+  }
+  .navbar-expand-xl .navbar-nav-scroll {
+    overflow: visible;
+  }
+  .navbar-expand-xl .navbar-collapse {
+    display: flex !important;
+    flex-basis: auto;
+  }
+  .navbar-expand-xl .navbar-toggler {
+    display: none;
+  }
+  .navbar-expand-xl .offcanvas {
+    position: static;
+    z-index: auto;
+    flex-grow: 1;
+    width: auto !important;
+    height: auto !important;
+    visibility: visible !important;
+    background-color: transparent !important;
+    border: 0 !important;
+    transform: none !important;
+    transition: none;
+  }
+  .navbar-expand-xl .offcanvas .offcanvas-header {
+    display: none;
+  }
+  .navbar-expand-xl .offcanvas .offcanvas-body {
+    display: flex;
+    flex-grow: 0;
+    padding: 0;
+    overflow-y: visible;
+  }
+}
+@media (min-width: 1400px) {
+  .navbar-expand-xxl {
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+  }
+  .navbar-expand-xxl .navbar-nav {
+    flex-direction: row;
+  }
+  .navbar-expand-xxl .navbar-nav .dropdown-menu {
+    position: absolute;
+  }
+  .navbar-expand-xxl .navbar-nav .nav-link {
+    padding-right: var(--bs-navbar-nav-link-padding-x);
+    padding-left: var(--bs-navbar-nav-link-padding-x);
+  }
+  .navbar-expand-xxl .navbar-nav-scroll {
+    overflow: visible;
+  }
+  .navbar-expand-xxl .navbar-collapse {
+    display: flex !important;
+    flex-basis: auto;
+  }
+  .navbar-expand-xxl .navbar-toggler {
+    display: none;
+  }
+  .navbar-expand-xxl .offcanvas {
+    position: static;
+    z-index: auto;
+    flex-grow: 1;
+    width: auto !important;
+    height: auto !important;
+    visibility: visible !important;
+    background-color: transparent !important;
+    border: 0 !important;
+    transform: none !important;
+    transition: none;
+  }
+  .navbar-expand-xxl .offcanvas .offcanvas-header {
+    display: none;
+  }
+  .navbar-expand-xxl .offcanvas .offcanvas-body {
+    display: flex;
+    flex-grow: 0;
+    padding: 0;
+    overflow-y: visible;
+  }
+}
+.navbar-expand {
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+}
+.navbar-expand .navbar-nav {
+  flex-direction: row;
+}
+.navbar-expand .navbar-nav .dropdown-menu {
+  position: absolute;
+}
+.navbar-expand .navbar-nav .nav-link {
+  padding-right: var(--bs-navbar-nav-link-padding-x);
+  padding-left: var(--bs-navbar-nav-link-padding-x);
+}
+.navbar-expand .navbar-nav-scroll {
+  overflow: visible;
+}
+.navbar-expand .navbar-collapse {
+  display: flex !important;
+  flex-basis: auto;
+}
+.navbar-expand .navbar-toggler {
+  display: none;
+}
+.navbar-expand .offcanvas {
+  position: static;
+  z-index: auto;
+  flex-grow: 1;
+  width: auto !important;
+  height: auto !important;
+  visibility: visible !important;
+  background-color: transparent !important;
+  border: 0 !important;
+  transform: none !important;
+  transition: none;
+}
+.navbar-expand .offcanvas .offcanvas-header {
+  display: none;
+}
+.navbar-expand .offcanvas .offcanvas-body {
+  display: flex;
+  flex-grow: 0;
+  padding: 0;
+  overflow-y: visible;
+}
+
+.navbar-dark,
+.navbar[data-bs-theme=dark] {
+  --bs-navbar-color: rgba(255, 255, 255, 0.55);
+  --bs-navbar-hover-color: rgba(255, 255, 255, 0.75);
+  --bs-navbar-disabled-color: rgba(255, 255, 255, 0.25);
+  --bs-navbar-active-color: #ffffff;
+  --bs-navbar-brand-color: #ffffff;
+  --bs-navbar-brand-hover-color: #ffffff;
+  --bs-navbar-toggler-border-color: rgba(255, 255, 255, 0.1);
+  --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255, 255, 255, 0.55%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+}
+
+[data-bs-theme=dark] .navbar-toggler-icon {
+  --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255, 255, 255, 0.55%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+}
+
+.card {
+  --bs-card-spacer-y: 1rem;
+  --bs-card-spacer-x: 1rem;
+  --bs-card-title-spacer-y: 0.5rem;
+  --bs-card-title-color: ;
+  --bs-card-subtitle-color: ;
+  --bs-card-border-width: var(--bs-border-width);
+  --bs-card-border-color: var(--bs-border-color-translucent);
+  --bs-card-border-radius: var(--bs-border-radius);
+  --bs-card-box-shadow: ;
+  --bs-card-inner-border-radius: calc(var(--bs-border-radius) - (var(--bs-border-width)));
+  --bs-card-cap-padding-y: 0.5rem;
+  --bs-card-cap-padding-x: 1rem;
+  --bs-card-cap-bg: rgba(var(--bs-body-color-rgb), 0.03);
+  --bs-card-cap-color: ;
+  --bs-card-height: ;
+  --bs-card-color: ;
+  --bs-card-bg: var(--bs-body-bg);
+  --bs-card-img-overlay-padding: 1rem;
+  --bs-card-group-margin: 0.75rem;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  height: var(--bs-card-height);
+  color: var(--bs-body-color);
+  word-wrap: break-word;
+  background-color: var(--bs-card-bg);
+  background-clip: border-box;
+  border: var(--bs-card-border-width) solid var(--bs-card-border-color);
+  border-radius: var(--bs-card-border-radius);
+}
+.card > hr {
+  margin-right: 0;
+  margin-left: 0;
+}
+.card > .list-group {
+  border-top: inherit;
+  border-bottom: inherit;
+}
+.card > .list-group:first-child {
+  border-top-width: 0;
+  border-top-left-radius: var(--bs-card-inner-border-radius);
+  border-top-right-radius: var(--bs-card-inner-border-radius);
+}
+.card > .list-group:last-child {
+  border-bottom-width: 0;
+  border-bottom-right-radius: var(--bs-card-inner-border-radius);
+  border-bottom-left-radius: var(--bs-card-inner-border-radius);
+}
+.card > .card-header + .list-group,
+.card > .list-group + .card-footer {
+  border-top: 0;
+}
+
+.card-body {
+  flex: 1 1 auto;
+  padding: var(--bs-card-spacer-y) var(--bs-card-spacer-x);
+  color: var(--bs-card-color);
+}
+
+.card-title {
+  margin-bottom: var(--bs-card-title-spacer-y);
+  color: var(--bs-card-title-color);
+}
+
+.card-subtitle {
+  margin-top: calc(-0.5 * var(--bs-card-title-spacer-y));
+  margin-bottom: 0;
+  color: var(--bs-card-subtitle-color);
+}
+
+.card-text:last-child {
+  margin-bottom: 0;
+}
+
+.card-link + .card-link {
+  margin-left: var(--bs-card-spacer-x);
+}
+
+.card-header {
+  padding: var(--bs-card-cap-padding-y) var(--bs-card-cap-padding-x);
+  margin-bottom: 0;
+  color: var(--bs-card-cap-color);
+  background-color: var(--bs-card-cap-bg);
+  border-bottom: var(--bs-card-border-width) solid var(--bs-card-border-color);
+}
+.card-header:first-child {
+  border-radius: var(--bs-card-inner-border-radius) var(--bs-card-inner-border-radius) 0 0;
+}
+
+.card-footer {
+  padding: var(--bs-card-cap-padding-y) var(--bs-card-cap-padding-x);
+  color: var(--bs-card-cap-color);
+  background-color: var(--bs-card-cap-bg);
+  border-top: var(--bs-card-border-width) solid var(--bs-card-border-color);
+}
+.card-footer:last-child {
+  border-radius: 0 0 var(--bs-card-inner-border-radius) var(--bs-card-inner-border-radius);
+}
+
+.card-header-tabs {
+  margin-right: calc(-0.5 * var(--bs-card-cap-padding-x));
+  margin-bottom: calc(-1 * var(--bs-card-cap-padding-y));
+  margin-left: calc(-0.5 * var(--bs-card-cap-padding-x));
+  border-bottom: 0;
+}
+.card-header-tabs .nav-link.active {
+  background-color: var(--bs-card-bg);
+  border-bottom-color: var(--bs-card-bg);
+}
+
+.card-header-pills {
+  margin-right: calc(-0.5 * var(--bs-card-cap-padding-x));
+  margin-left: calc(-0.5 * var(--bs-card-cap-padding-x));
+}
+
+.card-img-overlay {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  padding: var(--bs-card-img-overlay-padding);
+  border-radius: var(--bs-card-inner-border-radius);
+}
+
+.card-img,
+.card-img-top,
+.card-img-bottom {
+  width: 100%;
+}
+
+.card-img,
+.card-img-top {
+  border-top-left-radius: var(--bs-card-inner-border-radius);
+  border-top-right-radius: var(--bs-card-inner-border-radius);
+}
+
+.card-img,
+.card-img-bottom {
+  border-bottom-right-radius: var(--bs-card-inner-border-radius);
+  border-bottom-left-radius: var(--bs-card-inner-border-radius);
+}
+
+.card-group > .card {
+  margin-bottom: var(--bs-card-group-margin);
+}
+@media (min-width: 576px) {
+  .card-group {
+    display: flex;
+    flex-flow: row wrap;
+  }
+  .card-group > .card {
+    flex: 1 0 0;
+    margin-bottom: 0;
+  }
+  .card-group > .card + .card {
+    margin-left: 0;
+    border-left: 0;
+  }
+  .card-group > .card:not(:last-child) {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+  .card-group > .card:not(:last-child) > .card-img-top,
+  .card-group > .card:not(:last-child) > .card-header {
+    border-top-right-radius: 0;
+  }
+  .card-group > .card:not(:last-child) > .card-img-bottom,
+  .card-group > .card:not(:last-child) > .card-footer {
+    border-bottom-right-radius: 0;
+  }
+  .card-group > .card:not(:first-child) {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+  .card-group > .card:not(:first-child) > .card-img-top,
+  .card-group > .card:not(:first-child) > .card-header {
+    border-top-left-radius: 0;
+  }
+  .card-group > .card:not(:first-child) > .card-img-bottom,
+  .card-group > .card:not(:first-child) > .card-footer {
+    border-bottom-left-radius: 0;
+  }
+}
+
+.accordion {
+  --bs-accordion-color: var(--bs-body-color);
+  --bs-accordion-bg: var(--bs-body-bg);
+  --bs-accordion-transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out, border-radius 0.15s ease;
+  --bs-accordion-border-color: var(--bs-border-color);
+  --bs-accordion-border-width: var(--bs-border-width);
+  --bs-accordion-border-radius: var(--bs-border-radius);
+  --bs-accordion-inner-border-radius: calc(var(--bs-border-radius) - (var(--bs-border-width)));
+  --bs-accordion-btn-padding-x: 1.25rem;
+  --bs-accordion-btn-padding-y: 1rem;
+  --bs-accordion-btn-color: var(--bs-body-color);
+  --bs-accordion-btn-bg: var(--bs-accordion-bg);
+  --bs-accordion-btn-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23212529' stroke-linecap='round' stroke-linejoin='round'%3e%3cpath d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
+  --bs-accordion-btn-icon-width: 1.25rem;
+  --bs-accordion-btn-icon-transform: rotate(-180deg);
+  --bs-accordion-btn-icon-transition: transform 0.2s ease-in-out;
+  --bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='rgb%284, 10, 16.4%29' stroke-linecap='round' stroke-linejoin='round'%3e%3cpath d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
+  --bs-accordion-btn-focus-box-shadow: 0 0 0 0.25rem rgba(10, 25, 41, 0.25);
+  --bs-accordion-body-padding-x: 1.25rem;
+  --bs-accordion-body-padding-y: 1rem;
+  --bs-accordion-active-color: var(--bs-primary-text-emphasis);
+  --bs-accordion-active-bg: var(--bs-primary-bg-subtle);
+}
+
+.accordion-button {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: var(--bs-accordion-btn-padding-y) var(--bs-accordion-btn-padding-x);
+  font-size: 1rem;
+  color: var(--bs-accordion-btn-color);
+  text-align: left;
+  background-color: var(--bs-accordion-btn-bg);
+  border: 0;
+  border-radius: 0;
+  overflow-anchor: none;
+  transition: var(--bs-accordion-transition);
+}
+@media (prefers-reduced-motion: reduce) {
+  .accordion-button {
+    transition: none;
+  }
+}
+.accordion-button:not(.collapsed) {
+  color: var(--bs-accordion-active-color);
+  background-color: var(--bs-accordion-active-bg);
+  box-shadow: inset 0 calc(-1 * var(--bs-accordion-border-width)) 0 var(--bs-accordion-border-color);
+}
+.accordion-button:not(.collapsed)::after {
+  background-image: var(--bs-accordion-btn-active-icon);
+  transform: var(--bs-accordion-btn-icon-transform);
+}
+.accordion-button::after {
+  flex-shrink: 0;
+  width: var(--bs-accordion-btn-icon-width);
+  height: var(--bs-accordion-btn-icon-width);
+  margin-left: auto;
+  content: "";
+  background-image: var(--bs-accordion-btn-icon);
+  background-repeat: no-repeat;
+  background-size: var(--bs-accordion-btn-icon-width);
+  transition: var(--bs-accordion-btn-icon-transition);
+}
+@media (prefers-reduced-motion: reduce) {
+  .accordion-button::after {
+    transition: none;
+  }
+}
+.accordion-button:hover {
+  z-index: 2;
+}
+.accordion-button:focus {
+  z-index: 3;
+  outline: 0;
+  box-shadow: var(--bs-accordion-btn-focus-box-shadow);
+}
+
+.accordion-header {
+  margin-bottom: 0;
+}
+
+.accordion-item {
+  color: var(--bs-accordion-color);
+  background-color: var(--bs-accordion-bg);
+  border: var(--bs-accordion-border-width) solid var(--bs-accordion-border-color);
+}
+.accordion-item:first-of-type {
+  border-top-left-radius: var(--bs-accordion-border-radius);
+  border-top-right-radius: var(--bs-accordion-border-radius);
+}
+.accordion-item:first-of-type > .accordion-header .accordion-button {
+  border-top-left-radius: var(--bs-accordion-inner-border-radius);
+  border-top-right-radius: var(--bs-accordion-inner-border-radius);
+}
+.accordion-item:not(:first-of-type) {
+  border-top: 0;
+}
+.accordion-item:last-of-type {
+  border-bottom-right-radius: var(--bs-accordion-border-radius);
+  border-bottom-left-radius: var(--bs-accordion-border-radius);
+}
+.accordion-item:last-of-type > .accordion-header .accordion-button.collapsed {
+  border-bottom-right-radius: var(--bs-accordion-inner-border-radius);
+  border-bottom-left-radius: var(--bs-accordion-inner-border-radius);
+}
+.accordion-item:last-of-type > .accordion-collapse {
+  border-bottom-right-radius: var(--bs-accordion-border-radius);
+  border-bottom-left-radius: var(--bs-accordion-border-radius);
+}
+
+.accordion-body {
+  padding: var(--bs-accordion-body-padding-y) var(--bs-accordion-body-padding-x);
+}
+
+.accordion-flush > .accordion-item {
+  border-right: 0;
+  border-left: 0;
+  border-radius: 0;
+}
+.accordion-flush > .accordion-item:first-child {
+  border-top: 0;
+}
+.accordion-flush > .accordion-item:last-child {
+  border-bottom: 0;
+}
+.accordion-flush > .accordion-item > .accordion-collapse,
+.accordion-flush > .accordion-item > .accordion-header .accordion-button,
+.accordion-flush > .accordion-item > .accordion-header .accordion-button.collapsed {
+  border-radius: 0;
+}
+
+[data-bs-theme=dark] .accordion-button::after {
+  --bs-accordion-btn-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='rgb%28108, 117, 126.6%29'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708'/%3e%3c/svg%3e");
+  --bs-accordion-btn-active-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='rgb%28108, 117, 126.6%29'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708'/%3e%3c/svg%3e");
+}
+
+.breadcrumb {
+  --bs-breadcrumb-padding-x: 0;
+  --bs-breadcrumb-padding-y: 0;
+  --bs-breadcrumb-margin-bottom: 1rem;
+  --bs-breadcrumb-bg: ;
+  --bs-breadcrumb-border-radius: ;
+  --bs-breadcrumb-divider-color: var(--bs-secondary-color);
+  --bs-breadcrumb-item-padding-x: 0.5rem;
+  --bs-breadcrumb-item-active-color: var(--bs-secondary-color);
+  display: flex;
+  flex-wrap: wrap;
+  padding: var(--bs-breadcrumb-padding-y) var(--bs-breadcrumb-padding-x);
+  margin-bottom: var(--bs-breadcrumb-margin-bottom);
+  font-size: var(--bs-breadcrumb-font-size);
+  list-style: none;
+  background-color: var(--bs-breadcrumb-bg);
+  border-radius: var(--bs-breadcrumb-border-radius);
+}
+
+.breadcrumb-item + .breadcrumb-item {
+  padding-left: var(--bs-breadcrumb-item-padding-x);
+}
+.breadcrumb-item + .breadcrumb-item::before {
+  float: left;
+  padding-right: var(--bs-breadcrumb-item-padding-x);
+  color: var(--bs-breadcrumb-divider-color);
+  content: var(--bs-breadcrumb-divider, "/") /* rtl: var(--bs-breadcrumb-divider, "/") */;
+}
+.breadcrumb-item.active {
+  color: var(--bs-breadcrumb-item-active-color);
+}
+
+.pagination {
+  --bs-pagination-padding-x: 0.75rem;
+  --bs-pagination-padding-y: 0.375rem;
+  --bs-pagination-font-size: 1rem;
+  --bs-pagination-color: var(--bs-link-color);
+  --bs-pagination-bg: var(--bs-body-bg);
+  --bs-pagination-border-width: var(--bs-border-width);
+  --bs-pagination-border-color: var(--bs-border-color);
+  --bs-pagination-border-radius: var(--bs-border-radius);
+  --bs-pagination-hover-color: var(--bs-link-hover-color);
+  --bs-pagination-hover-bg: var(--bs-tertiary-bg);
+  --bs-pagination-hover-border-color: var(--bs-border-color);
+  --bs-pagination-focus-color: var(--bs-link-hover-color);
+  --bs-pagination-focus-bg: var(--bs-secondary-bg);
+  --bs-pagination-focus-box-shadow: 0 0 0 0.25rem rgba(10, 25, 41, 0.25);
+  --bs-pagination-active-color: #ffffff;
+  --bs-pagination-active-bg: #0A1929;
+  --bs-pagination-active-border-color: #0A1929;
+  --bs-pagination-disabled-color: var(--bs-secondary-color);
+  --bs-pagination-disabled-bg: var(--bs-secondary-bg);
+  --bs-pagination-disabled-border-color: var(--bs-border-color);
+  display: flex;
+  padding-left: 0;
+  list-style: none;
+}
+
+.page-link {
+  position: relative;
+  display: block;
+  padding: var(--bs-pagination-padding-y) var(--bs-pagination-padding-x);
+  font-size: var(--bs-pagination-font-size);
+  color: var(--bs-pagination-color);
+  text-decoration: none;
+  background-color: var(--bs-pagination-bg);
+  border: var(--bs-pagination-border-width) solid var(--bs-pagination-border-color);
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .page-link {
+    transition: none;
+  }
+}
+.page-link:hover {
+  z-index: 2;
+  color: var(--bs-pagination-hover-color);
+  background-color: var(--bs-pagination-hover-bg);
+  border-color: var(--bs-pagination-hover-border-color);
+}
+.page-link:focus {
+  z-index: 3;
+  color: var(--bs-pagination-focus-color);
+  background-color: var(--bs-pagination-focus-bg);
+  outline: 0;
+  box-shadow: var(--bs-pagination-focus-box-shadow);
+}
+.page-link.active, .active > .page-link {
+  z-index: 3;
+  color: var(--bs-pagination-active-color);
+  background-color: var(--bs-pagination-active-bg);
+  border-color: var(--bs-pagination-active-border-color);
+}
+.page-link.disabled, .disabled > .page-link {
+  color: var(--bs-pagination-disabled-color);
+  pointer-events: none;
+  background-color: var(--bs-pagination-disabled-bg);
+  border-color: var(--bs-pagination-disabled-border-color);
+}
+
+.page-item:not(:first-child) .page-link {
+  margin-left: calc(-1 * var(--bs-border-width));
+}
+.page-item:first-child .page-link {
+  border-top-left-radius: var(--bs-pagination-border-radius);
+  border-bottom-left-radius: var(--bs-pagination-border-radius);
+}
+.page-item:last-child .page-link {
+  border-top-right-radius: var(--bs-pagination-border-radius);
+  border-bottom-right-radius: var(--bs-pagination-border-radius);
+}
+
+.pagination-lg {
+  --bs-pagination-padding-x: 1.5rem;
+  --bs-pagination-padding-y: 0.75rem;
+  --bs-pagination-font-size: 1.25rem;
+  --bs-pagination-border-radius: var(--bs-border-radius-lg);
+}
+
+.pagination-sm {
+  --bs-pagination-padding-x: 0.5rem;
+  --bs-pagination-padding-y: 0.25rem;
+  --bs-pagination-font-size: 0.875rem;
+  --bs-pagination-border-radius: var(--bs-border-radius-sm);
+}
+
+.badge {
+  --bs-badge-padding-x: 0.65em;
+  --bs-badge-padding-y: 0.35em;
+  --bs-badge-font-size: 0.75em;
+  --bs-badge-font-weight: 700;
+  --bs-badge-color: #ffffff;
+  --bs-badge-border-radius: var(--bs-border-radius);
+  display: inline-block;
+  padding: var(--bs-badge-padding-y) var(--bs-badge-padding-x);
+  font-size: var(--bs-badge-font-size);
+  font-weight: var(--bs-badge-font-weight);
+  line-height: 1;
+  color: var(--bs-badge-color);
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: var(--bs-badge-border-radius);
+}
+.badge:empty {
+  display: none;
+}
+
+.btn .badge {
+  position: relative;
+  top: -1px;
+}
+
+.alert {
+  --bs-alert-bg: transparent;
+  --bs-alert-padding-x: 1rem;
+  --bs-alert-padding-y: 1rem;
+  --bs-alert-margin-bottom: 1rem;
+  --bs-alert-color: inherit;
+  --bs-alert-border-color: transparent;
+  --bs-alert-border: var(--bs-border-width) solid var(--bs-alert-border-color);
+  --bs-alert-border-radius: var(--bs-border-radius);
+  --bs-alert-link-color: inherit;
+  position: relative;
+  padding: var(--bs-alert-padding-y) var(--bs-alert-padding-x);
+  margin-bottom: var(--bs-alert-margin-bottom);
+  color: var(--bs-alert-color);
+  background-color: var(--bs-alert-bg);
+  border: var(--bs-alert-border);
+  border-radius: var(--bs-alert-border-radius);
+}
+
+.alert-heading {
+  color: inherit;
+}
+
+.alert-link {
+  font-weight: 700;
+  color: var(--bs-alert-link-color);
+}
+
+.alert-dismissible {
+  padding-right: 3rem;
+}
+.alert-dismissible .btn-close {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 2;
+  padding: 1.25rem 1rem;
+}
+
+.alert-primary {
+  --bs-alert-color: var(--bs-primary-text-emphasis);
+  --bs-alert-bg: var(--bs-primary-bg-subtle);
+  --bs-alert-border-color: var(--bs-primary-border-subtle);
+  --bs-alert-link-color: var(--bs-primary-text-emphasis);
+}
+
+.alert-secondary {
+  --bs-alert-color: var(--bs-secondary-text-emphasis);
+  --bs-alert-bg: var(--bs-secondary-bg-subtle);
+  --bs-alert-border-color: var(--bs-secondary-border-subtle);
+  --bs-alert-link-color: var(--bs-secondary-text-emphasis);
+}
+
+.alert-success {
+  --bs-alert-color: var(--bs-success-text-emphasis);
+  --bs-alert-bg: var(--bs-success-bg-subtle);
+  --bs-alert-border-color: var(--bs-success-border-subtle);
+  --bs-alert-link-color: var(--bs-success-text-emphasis);
+}
+
+.alert-info {
+  --bs-alert-color: var(--bs-info-text-emphasis);
+  --bs-alert-bg: var(--bs-info-bg-subtle);
+  --bs-alert-border-color: var(--bs-info-border-subtle);
+  --bs-alert-link-color: var(--bs-info-text-emphasis);
+}
+
+.alert-warning {
+  --bs-alert-color: var(--bs-warning-text-emphasis);
+  --bs-alert-bg: var(--bs-warning-bg-subtle);
+  --bs-alert-border-color: var(--bs-warning-border-subtle);
+  --bs-alert-link-color: var(--bs-warning-text-emphasis);
+}
+
+.alert-danger {
+  --bs-alert-color: var(--bs-danger-text-emphasis);
+  --bs-alert-bg: var(--bs-danger-bg-subtle);
+  --bs-alert-border-color: var(--bs-danger-border-subtle);
+  --bs-alert-link-color: var(--bs-danger-text-emphasis);
+}
+
+.alert-light {
+  --bs-alert-color: var(--bs-light-text-emphasis);
+  --bs-alert-bg: var(--bs-light-bg-subtle);
+  --bs-alert-border-color: var(--bs-light-border-subtle);
+  --bs-alert-link-color: var(--bs-light-text-emphasis);
+}
+
+.alert-dark {
+  --bs-alert-color: var(--bs-dark-text-emphasis);
+  --bs-alert-bg: var(--bs-dark-bg-subtle);
+  --bs-alert-border-color: var(--bs-dark-border-subtle);
+  --bs-alert-link-color: var(--bs-dark-text-emphasis);
+}
+
+@keyframes progress-bar-stripes {
+  0% {
+    background-position-x: var(--bs-progress-height);
+  }
+}
+.progress,
+.progress-stacked {
+  --bs-progress-height: 1rem;
+  --bs-progress-font-size: 0.75rem;
+  --bs-progress-bg: var(--bs-secondary-bg);
+  --bs-progress-border-radius: var(--bs-border-radius);
+  --bs-progress-box-shadow: var(--bs-box-shadow-inset);
+  --bs-progress-bar-color: #ffffff;
+  --bs-progress-bar-bg: #0A1929;
+  --bs-progress-bar-transition: width 0.6s ease;
+  display: flex;
+  height: var(--bs-progress-height);
+  overflow: hidden;
+  font-size: var(--bs-progress-font-size);
+  background-color: var(--bs-progress-bg);
+  border-radius: var(--bs-progress-border-radius);
+}
+
+.progress-bar {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  overflow: hidden;
+  color: var(--bs-progress-bar-color);
+  text-align: center;
+  white-space: nowrap;
+  background-color: var(--bs-progress-bar-bg);
+  transition: var(--bs-progress-bar-transition);
+}
+@media (prefers-reduced-motion: reduce) {
+  .progress-bar {
+    transition: none;
+  }
+}
+
+.progress-bar-striped {
+  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-size: var(--bs-progress-height) var(--bs-progress-height);
+}
+
+.progress-stacked > .progress {
+  overflow: visible;
+}
+
+.progress-stacked > .progress > .progress-bar {
+  width: 100%;
+}
+
+.progress-bar-animated {
+  animation: 1s linear infinite progress-bar-stripes;
+}
+@media (prefers-reduced-motion: reduce) {
+  .progress-bar-animated {
+    animation: none;
+  }
+}
+
+.list-group {
+  --bs-list-group-color: var(--bs-body-color);
+  --bs-list-group-bg: var(--bs-body-bg);
+  --bs-list-group-border-color: var(--bs-border-color);
+  --bs-list-group-border-width: var(--bs-border-width);
+  --bs-list-group-border-radius: var(--bs-border-radius);
+  --bs-list-group-item-padding-x: 1rem;
+  --bs-list-group-item-padding-y: 0.5rem;
+  --bs-list-group-action-color: var(--bs-secondary-color);
+  --bs-list-group-action-hover-color: var(--bs-emphasis-color);
+  --bs-list-group-action-hover-bg: var(--bs-tertiary-bg);
+  --bs-list-group-action-active-color: var(--bs-body-color);
+  --bs-list-group-action-active-bg: var(--bs-secondary-bg);
+  --bs-list-group-disabled-color: var(--bs-secondary-color);
+  --bs-list-group-disabled-bg: var(--bs-body-bg);
+  --bs-list-group-active-color: #ffffff;
+  --bs-list-group-active-bg: #0A1929;
+  --bs-list-group-active-border-color: #0A1929;
+  display: flex;
+  flex-direction: column;
+  padding-left: 0;
+  margin-bottom: 0;
+  border-radius: var(--bs-list-group-border-radius);
+}
+
+.list-group-numbered {
+  list-style-type: none;
+  counter-reset: section;
+}
+.list-group-numbered > .list-group-item::before {
+  content: counters(section, ".") ". ";
+  counter-increment: section;
+}
+
+.list-group-item {
+  position: relative;
+  display: block;
+  padding: var(--bs-list-group-item-padding-y) var(--bs-list-group-item-padding-x);
+  color: var(--bs-list-group-color);
+  text-decoration: none;
+  background-color: var(--bs-list-group-bg);
+  border: var(--bs-list-group-border-width) solid var(--bs-list-group-border-color);
+}
+.list-group-item:first-child {
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+}
+.list-group-item:last-child {
+  border-bottom-right-radius: inherit;
+  border-bottom-left-radius: inherit;
+}
+.list-group-item.disabled, .list-group-item:disabled {
+  color: var(--bs-list-group-disabled-color);
+  pointer-events: none;
+  background-color: var(--bs-list-group-disabled-bg);
+}
+.list-group-item.active {
+  z-index: 2;
+  color: var(--bs-list-group-active-color);
+  background-color: var(--bs-list-group-active-bg);
+  border-color: var(--bs-list-group-active-border-color);
+}
+.list-group-item + .list-group-item {
+  border-top-width: 0;
+}
+.list-group-item + .list-group-item.active {
+  margin-top: calc(-1 * var(--bs-list-group-border-width));
+  border-top-width: var(--bs-list-group-border-width);
+}
+
+.list-group-item-action {
+  width: 100%;
+  color: var(--bs-list-group-action-color);
+  text-align: inherit;
+}
+.list-group-item-action:not(.active):hover, .list-group-item-action:not(.active):focus {
+  z-index: 1;
+  color: var(--bs-list-group-action-hover-color);
+  text-decoration: none;
+  background-color: var(--bs-list-group-action-hover-bg);
+}
+.list-group-item-action:not(.active):active {
+  color: var(--bs-list-group-action-active-color);
+  background-color: var(--bs-list-group-action-active-bg);
+}
+
+.list-group-horizontal {
+  flex-direction: row;
+}
+.list-group-horizontal > .list-group-item:first-child:not(:last-child) {
+  border-bottom-left-radius: var(--bs-list-group-border-radius);
+  border-top-right-radius: 0;
+}
+.list-group-horizontal > .list-group-item:last-child:not(:first-child) {
+  border-top-right-radius: var(--bs-list-group-border-radius);
+  border-bottom-left-radius: 0;
+}
+.list-group-horizontal > .list-group-item.active {
+  margin-top: 0;
+}
+.list-group-horizontal > .list-group-item + .list-group-item {
+  border-top-width: var(--bs-list-group-border-width);
+  border-left-width: 0;
+}
+.list-group-horizontal > .list-group-item + .list-group-item.active {
+  margin-left: calc(-1 * var(--bs-list-group-border-width));
+  border-left-width: var(--bs-list-group-border-width);
+}
+
+@media (min-width: 576px) {
+  .list-group-horizontal-sm {
+    flex-direction: row;
+  }
+  .list-group-horizontal-sm > .list-group-item:first-child:not(:last-child) {
+    border-bottom-left-radius: var(--bs-list-group-border-radius);
+    border-top-right-radius: 0;
+  }
+  .list-group-horizontal-sm > .list-group-item:last-child:not(:first-child) {
+    border-top-right-radius: var(--bs-list-group-border-radius);
+    border-bottom-left-radius: 0;
+  }
+  .list-group-horizontal-sm > .list-group-item.active {
+    margin-top: 0;
+  }
+  .list-group-horizontal-sm > .list-group-item + .list-group-item {
+    border-top-width: var(--bs-list-group-border-width);
+    border-left-width: 0;
+  }
+  .list-group-horizontal-sm > .list-group-item + .list-group-item.active {
+    margin-left: calc(-1 * var(--bs-list-group-border-width));
+    border-left-width: var(--bs-list-group-border-width);
+  }
+}
+@media (min-width: 768px) {
+  .list-group-horizontal-md {
+    flex-direction: row;
+  }
+  .list-group-horizontal-md > .list-group-item:first-child:not(:last-child) {
+    border-bottom-left-radius: var(--bs-list-group-border-radius);
+    border-top-right-radius: 0;
+  }
+  .list-group-horizontal-md > .list-group-item:last-child:not(:first-child) {
+    border-top-right-radius: var(--bs-list-group-border-radius);
+    border-bottom-left-radius: 0;
+  }
+  .list-group-horizontal-md > .list-group-item.active {
+    margin-top: 0;
+  }
+  .list-group-horizontal-md > .list-group-item + .list-group-item {
+    border-top-width: var(--bs-list-group-border-width);
+    border-left-width: 0;
+  }
+  .list-group-horizontal-md > .list-group-item + .list-group-item.active {
+    margin-left: calc(-1 * var(--bs-list-group-border-width));
+    border-left-width: var(--bs-list-group-border-width);
+  }
+}
+@media (min-width: 992px) {
+  .list-group-horizontal-lg {
+    flex-direction: row;
+  }
+  .list-group-horizontal-lg > .list-group-item:first-child:not(:last-child) {
+    border-bottom-left-radius: var(--bs-list-group-border-radius);
+    border-top-right-radius: 0;
+  }
+  .list-group-horizontal-lg > .list-group-item:last-child:not(:first-child) {
+    border-top-right-radius: var(--bs-list-group-border-radius);
+    border-bottom-left-radius: 0;
+  }
+  .list-group-horizontal-lg > .list-group-item.active {
+    margin-top: 0;
+  }
+  .list-group-horizontal-lg > .list-group-item + .list-group-item {
+    border-top-width: var(--bs-list-group-border-width);
+    border-left-width: 0;
+  }
+  .list-group-horizontal-lg > .list-group-item + .list-group-item.active {
+    margin-left: calc(-1 * var(--bs-list-group-border-width));
+    border-left-width: var(--bs-list-group-border-width);
+  }
+}
+@media (min-width: 1200px) {
+  .list-group-horizontal-xl {
+    flex-direction: row;
+  }
+  .list-group-horizontal-xl > .list-group-item:first-child:not(:last-child) {
+    border-bottom-left-radius: var(--bs-list-group-border-radius);
+    border-top-right-radius: 0;
+  }
+  .list-group-horizontal-xl > .list-group-item:last-child:not(:first-child) {
+    border-top-right-radius: var(--bs-list-group-border-radius);
+    border-bottom-left-radius: 0;
+  }
+  .list-group-horizontal-xl > .list-group-item.active {
+    margin-top: 0;
+  }
+  .list-group-horizontal-xl > .list-group-item + .list-group-item {
+    border-top-width: var(--bs-list-group-border-width);
+    border-left-width: 0;
+  }
+  .list-group-horizontal-xl > .list-group-item + .list-group-item.active {
+    margin-left: calc(-1 * var(--bs-list-group-border-width));
+    border-left-width: var(--bs-list-group-border-width);
+  }
+}
+@media (min-width: 1400px) {
+  .list-group-horizontal-xxl {
+    flex-direction: row;
+  }
+  .list-group-horizontal-xxl > .list-group-item:first-child:not(:last-child) {
+    border-bottom-left-radius: var(--bs-list-group-border-radius);
+    border-top-right-radius: 0;
+  }
+  .list-group-horizontal-xxl > .list-group-item:last-child:not(:first-child) {
+    border-top-right-radius: var(--bs-list-group-border-radius);
+    border-bottom-left-radius: 0;
+  }
+  .list-group-horizontal-xxl > .list-group-item.active {
+    margin-top: 0;
+  }
+  .list-group-horizontal-xxl > .list-group-item + .list-group-item {
+    border-top-width: var(--bs-list-group-border-width);
+    border-left-width: 0;
+  }
+  .list-group-horizontal-xxl > .list-group-item + .list-group-item.active {
+    margin-left: calc(-1 * var(--bs-list-group-border-width));
+    border-left-width: var(--bs-list-group-border-width);
+  }
+}
+.list-group-flush {
+  border-radius: 0;
+}
+.list-group-flush > .list-group-item {
+  border-width: 0 0 var(--bs-list-group-border-width);
+}
+.list-group-flush > .list-group-item:last-child {
+  border-bottom-width: 0;
+}
+
+.list-group-item-primary {
+  --bs-list-group-color: var(--bs-primary-text-emphasis);
+  --bs-list-group-bg: var(--bs-primary-bg-subtle);
+  --bs-list-group-border-color: var(--bs-primary-border-subtle);
+  --bs-list-group-action-hover-color: var(--bs-emphasis-color);
+  --bs-list-group-action-hover-bg: var(--bs-primary-border-subtle);
+  --bs-list-group-action-active-color: var(--bs-emphasis-color);
+  --bs-list-group-action-active-bg: var(--bs-primary-border-subtle);
+  --bs-list-group-active-color: var(--bs-primary-bg-subtle);
+  --bs-list-group-active-bg: var(--bs-primary-text-emphasis);
+  --bs-list-group-active-border-color: var(--bs-primary-text-emphasis);
+}
+
+.list-group-item-secondary {
+  --bs-list-group-color: var(--bs-secondary-text-emphasis);
+  --bs-list-group-bg: var(--bs-secondary-bg-subtle);
+  --bs-list-group-border-color: var(--bs-secondary-border-subtle);
+  --bs-list-group-action-hover-color: var(--bs-emphasis-color);
+  --bs-list-group-action-hover-bg: var(--bs-secondary-border-subtle);
+  --bs-list-group-action-active-color: var(--bs-emphasis-color);
+  --bs-list-group-action-active-bg: var(--bs-secondary-border-subtle);
+  --bs-list-group-active-color: var(--bs-secondary-bg-subtle);
+  --bs-list-group-active-bg: var(--bs-secondary-text-emphasis);
+  --bs-list-group-active-border-color: var(--bs-secondary-text-emphasis);
+}
+
+.list-group-item-success {
+  --bs-list-group-color: var(--bs-success-text-emphasis);
+  --bs-list-group-bg: var(--bs-success-bg-subtle);
+  --bs-list-group-border-color: var(--bs-success-border-subtle);
+  --bs-list-group-action-hover-color: var(--bs-emphasis-color);
+  --bs-list-group-action-hover-bg: var(--bs-success-border-subtle);
+  --bs-list-group-action-active-color: var(--bs-emphasis-color);
+  --bs-list-group-action-active-bg: var(--bs-success-border-subtle);
+  --bs-list-group-active-color: var(--bs-success-bg-subtle);
+  --bs-list-group-active-bg: var(--bs-success-text-emphasis);
+  --bs-list-group-active-border-color: var(--bs-success-text-emphasis);
+}
+
+.list-group-item-info {
+  --bs-list-group-color: var(--bs-info-text-emphasis);
+  --bs-list-group-bg: var(--bs-info-bg-subtle);
+  --bs-list-group-border-color: var(--bs-info-border-subtle);
+  --bs-list-group-action-hover-color: var(--bs-emphasis-color);
+  --bs-list-group-action-hover-bg: var(--bs-info-border-subtle);
+  --bs-list-group-action-active-color: var(--bs-emphasis-color);
+  --bs-list-group-action-active-bg: var(--bs-info-border-subtle);
+  --bs-list-group-active-color: var(--bs-info-bg-subtle);
+  --bs-list-group-active-bg: var(--bs-info-text-emphasis);
+  --bs-list-group-active-border-color: var(--bs-info-text-emphasis);
+}
+
+.list-group-item-warning {
+  --bs-list-group-color: var(--bs-warning-text-emphasis);
+  --bs-list-group-bg: var(--bs-warning-bg-subtle);
+  --bs-list-group-border-color: var(--bs-warning-border-subtle);
+  --bs-list-group-action-hover-color: var(--bs-emphasis-color);
+  --bs-list-group-action-hover-bg: var(--bs-warning-border-subtle);
+  --bs-list-group-action-active-color: var(--bs-emphasis-color);
+  --bs-list-group-action-active-bg: var(--bs-warning-border-subtle);
+  --bs-list-group-active-color: var(--bs-warning-bg-subtle);
+  --bs-list-group-active-bg: var(--bs-warning-text-emphasis);
+  --bs-list-group-active-border-color: var(--bs-warning-text-emphasis);
+}
+
+.list-group-item-danger {
+  --bs-list-group-color: var(--bs-danger-text-emphasis);
+  --bs-list-group-bg: var(--bs-danger-bg-subtle);
+  --bs-list-group-border-color: var(--bs-danger-border-subtle);
+  --bs-list-group-action-hover-color: var(--bs-emphasis-color);
+  --bs-list-group-action-hover-bg: var(--bs-danger-border-subtle);
+  --bs-list-group-action-active-color: var(--bs-emphasis-color);
+  --bs-list-group-action-active-bg: var(--bs-danger-border-subtle);
+  --bs-list-group-active-color: var(--bs-danger-bg-subtle);
+  --bs-list-group-active-bg: var(--bs-danger-text-emphasis);
+  --bs-list-group-active-border-color: var(--bs-danger-text-emphasis);
+}
+
+.list-group-item-light {
+  --bs-list-group-color: var(--bs-light-text-emphasis);
+  --bs-list-group-bg: var(--bs-light-bg-subtle);
+  --bs-list-group-border-color: var(--bs-light-border-subtle);
+  --bs-list-group-action-hover-color: var(--bs-emphasis-color);
+  --bs-list-group-action-hover-bg: var(--bs-light-border-subtle);
+  --bs-list-group-action-active-color: var(--bs-emphasis-color);
+  --bs-list-group-action-active-bg: var(--bs-light-border-subtle);
+  --bs-list-group-active-color: var(--bs-light-bg-subtle);
+  --bs-list-group-active-bg: var(--bs-light-text-emphasis);
+  --bs-list-group-active-border-color: var(--bs-light-text-emphasis);
+}
+
+.list-group-item-dark {
+  --bs-list-group-color: var(--bs-dark-text-emphasis);
+  --bs-list-group-bg: var(--bs-dark-bg-subtle);
+  --bs-list-group-border-color: var(--bs-dark-border-subtle);
+  --bs-list-group-action-hover-color: var(--bs-emphasis-color);
+  --bs-list-group-action-hover-bg: var(--bs-dark-border-subtle);
+  --bs-list-group-action-active-color: var(--bs-emphasis-color);
+  --bs-list-group-action-active-bg: var(--bs-dark-border-subtle);
+  --bs-list-group-active-color: var(--bs-dark-bg-subtle);
+  --bs-list-group-active-bg: var(--bs-dark-text-emphasis);
+  --bs-list-group-active-border-color: var(--bs-dark-text-emphasis);
+}
+
+.btn-close {
+  --bs-btn-close-color: #000000;
+  --bs-btn-close-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23000000'%3e%3cpath d='M.293.293a1 1 0 0 1 1.414 0L8 6.586 14.293.293a1 1 0 1 1 1.414 1.414L9.414 8l6.293 6.293a1 1 0 0 1-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L6.586 8 .293 1.707a1 1 0 0 1 0-1.414'/%3e%3c/svg%3e");
+  --bs-btn-close-opacity: 0.5;
+  --bs-btn-close-hover-opacity: 0.75;
+  --bs-btn-close-focus-shadow: 0 0 0 0.25rem rgba(10, 25, 41, 0.25);
+  --bs-btn-close-focus-opacity: 1;
+  --bs-btn-close-disabled-opacity: 0.25;
+  box-sizing: content-box;
+  width: 1em;
+  height: 1em;
+  padding: 0.25em 0.25em;
+  color: var(--bs-btn-close-color);
+  background: transparent var(--bs-btn-close-bg) center/1em auto no-repeat;
+  filter: var(--bs-btn-close-filter);
+  border: 0;
+  border-radius: 0.375rem;
+  opacity: var(--bs-btn-close-opacity);
+}
+.btn-close:hover {
+  color: var(--bs-btn-close-color);
+  text-decoration: none;
+  opacity: var(--bs-btn-close-hover-opacity);
+}
+.btn-close:focus {
+  outline: 0;
+  box-shadow: var(--bs-btn-close-focus-shadow);
+  opacity: var(--bs-btn-close-focus-opacity);
+}
+.btn-close:disabled, .btn-close.disabled {
+  pointer-events: none;
+  user-select: none;
+  opacity: var(--bs-btn-close-disabled-opacity);
+}
+
+.btn-close-white {
+  --bs-btn-close-filter: invert(1) grayscale(100%) brightness(200%);
+}
+
+:root,
+[data-bs-theme=light] {
+  --bs-btn-close-filter: ;
+}
+
+[data-bs-theme=dark] {
+  --bs-btn-close-filter: invert(1) grayscale(100%) brightness(200%);
+}
+
+.toast {
+  --bs-toast-zindex: 1090;
+  --bs-toast-padding-x: 0.75rem;
+  --bs-toast-padding-y: 0.5rem;
+  --bs-toast-spacing: 1.5rem;
+  --bs-toast-max-width: 350px;
+  --bs-toast-font-size: 0.875rem;
+  --bs-toast-color: ;
+  --bs-toast-bg: rgba(var(--bs-body-bg-rgb), 0.85);
+  --bs-toast-border-width: var(--bs-border-width);
+  --bs-toast-border-color: var(--bs-border-color-translucent);
+  --bs-toast-border-radius: var(--bs-border-radius);
+  --bs-toast-box-shadow: var(--bs-box-shadow);
+  --bs-toast-header-color: var(--bs-secondary-color);
+  --bs-toast-header-bg: rgba(var(--bs-body-bg-rgb), 0.85);
+  --bs-toast-header-border-color: var(--bs-border-color-translucent);
+  width: var(--bs-toast-max-width);
+  max-width: 100%;
+  font-size: var(--bs-toast-font-size);
+  color: var(--bs-toast-color);
+  pointer-events: auto;
+  background-color: var(--bs-toast-bg);
+  background-clip: padding-box;
+  border: var(--bs-toast-border-width) solid var(--bs-toast-border-color);
+  box-shadow: var(--bs-toast-box-shadow);
+  border-radius: var(--bs-toast-border-radius);
+}
+.toast.showing {
+  opacity: 0;
+}
+.toast:not(.show) {
+  display: none;
+}
+
+.toast-container {
+  --bs-toast-zindex: 1090;
+  position: absolute;
+  z-index: var(--bs-toast-zindex);
+  width: max-content;
+  max-width: 100%;
+  pointer-events: none;
+}
+.toast-container > :not(:last-child) {
+  margin-bottom: var(--bs-toast-spacing);
+}
+
+.toast-header {
+  display: flex;
+  align-items: center;
+  padding: var(--bs-toast-padding-y) var(--bs-toast-padding-x);
+  color: var(--bs-toast-header-color);
+  background-color: var(--bs-toast-header-bg);
+  background-clip: padding-box;
+  border-bottom: var(--bs-toast-border-width) solid var(--bs-toast-header-border-color);
+  border-top-left-radius: calc(var(--bs-toast-border-radius) - var(--bs-toast-border-width));
+  border-top-right-radius: calc(var(--bs-toast-border-radius) - var(--bs-toast-border-width));
+}
+.toast-header .btn-close {
+  margin-right: calc(-0.5 * var(--bs-toast-padding-x));
+  margin-left: var(--bs-toast-padding-x);
+}
+
+.toast-body {
+  padding: var(--bs-toast-padding-x);
+  word-wrap: break-word;
+}
+
+.modal {
+  --bs-modal-zindex: 1055;
+  --bs-modal-width: 500px;
+  --bs-modal-padding: 1rem;
+  --bs-modal-margin: 0.5rem;
+  --bs-modal-color: var(--bs-body-color);
+  --bs-modal-bg: var(--bs-body-bg);
+  --bs-modal-border-color: var(--bs-border-color-translucent);
+  --bs-modal-border-width: var(--bs-border-width);
+  --bs-modal-border-radius: var(--bs-border-radius-lg);
+  --bs-modal-box-shadow: var(--bs-box-shadow-sm);
+  --bs-modal-inner-border-radius: calc(var(--bs-border-radius-lg) - (var(--bs-border-width)));
+  --bs-modal-header-padding-x: 1rem;
+  --bs-modal-header-padding-y: 1rem;
+  --bs-modal-header-padding: 1rem 1rem;
+  --bs-modal-header-border-color: var(--bs-border-color);
+  --bs-modal-header-border-width: var(--bs-border-width);
+  --bs-modal-title-line-height: 1.5;
+  --bs-modal-footer-gap: 0.5rem;
+  --bs-modal-footer-bg: ;
+  --bs-modal-footer-border-color: var(--bs-border-color);
+  --bs-modal-footer-border-width: var(--bs-border-width);
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: var(--bs-modal-zindex);
+  display: none;
+  width: 100%;
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+  outline: 0;
+}
+
+.modal-dialog {
+  position: relative;
+  width: auto;
+  margin: var(--bs-modal-margin);
+  pointer-events: none;
+}
+.modal.fade .modal-dialog {
+  transform: translate(0, -50px);
+  transition: transform 0.3s ease-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .modal.fade .modal-dialog {
+    transition: none;
+  }
+}
+.modal.show .modal-dialog {
+  transform: none;
+}
+.modal.modal-static .modal-dialog {
+  transform: scale(1.02);
+}
+
+.modal-dialog-scrollable {
+  height: calc(100% - var(--bs-modal-margin) * 2);
+}
+.modal-dialog-scrollable .modal-content {
+  max-height: 100%;
+  overflow: hidden;
+}
+.modal-dialog-scrollable .modal-body {
+  overflow-y: auto;
+}
+
+.modal-dialog-centered {
+  display: flex;
+  align-items: center;
+  min-height: calc(100% - var(--bs-modal-margin) * 2);
+}
+
+.modal-content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  color: var(--bs-modal-color);
+  pointer-events: auto;
+  background-color: var(--bs-modal-bg);
+  background-clip: padding-box;
+  border: var(--bs-modal-border-width) solid var(--bs-modal-border-color);
+  border-radius: var(--bs-modal-border-radius);
+  outline: 0;
+}
+
+.modal-backdrop {
+  --bs-backdrop-zindex: 1050;
+  --bs-backdrop-bg: #000000;
+  --bs-backdrop-opacity: 0.5;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: var(--bs-backdrop-zindex);
+  width: 100vw;
+  height: 100vh;
+  background-color: var(--bs-backdrop-bg);
+}
+.modal-backdrop.fade {
+  opacity: 0;
+}
+.modal-backdrop.show {
+  opacity: var(--bs-backdrop-opacity);
+}
+
+.modal-header {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  padding: var(--bs-modal-header-padding);
+  border-bottom: var(--bs-modal-header-border-width) solid var(--bs-modal-header-border-color);
+  border-top-left-radius: var(--bs-modal-inner-border-radius);
+  border-top-right-radius: var(--bs-modal-inner-border-radius);
+}
+.modal-header .btn-close {
+  padding: calc(var(--bs-modal-header-padding-y) * 0.5) calc(var(--bs-modal-header-padding-x) * 0.5);
+  margin-top: calc(-0.5 * var(--bs-modal-header-padding-y));
+  margin-right: calc(-0.5 * var(--bs-modal-header-padding-x));
+  margin-bottom: calc(-0.5 * var(--bs-modal-header-padding-y));
+  margin-left: auto;
+}
+
+.modal-title {
+  margin-bottom: 0;
+  line-height: var(--bs-modal-title-line-height);
+}
+
+.modal-body {
+  position: relative;
+  flex: 1 1 auto;
+  padding: var(--bs-modal-padding);
+}
+
+.modal-footer {
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  padding: calc(var(--bs-modal-padding) - var(--bs-modal-footer-gap) * 0.5);
+  background-color: var(--bs-modal-footer-bg);
+  border-top: var(--bs-modal-footer-border-width) solid var(--bs-modal-footer-border-color);
+  border-bottom-right-radius: var(--bs-modal-inner-border-radius);
+  border-bottom-left-radius: var(--bs-modal-inner-border-radius);
+}
+.modal-footer > * {
+  margin: calc(var(--bs-modal-footer-gap) * 0.5);
+}
+
+@media (min-width: 576px) {
+  .modal {
+    --bs-modal-margin: 1.75rem;
+    --bs-modal-box-shadow: var(--bs-box-shadow);
+  }
+  .modal-dialog {
+    max-width: var(--bs-modal-width);
+    margin-right: auto;
+    margin-left: auto;
+  }
+  .modal-sm {
+    --bs-modal-width: 300px;
+  }
+}
+@media (min-width: 992px) {
+  .modal-lg,
+  .modal-xl {
+    --bs-modal-width: 800px;
+  }
+}
+@media (min-width: 1200px) {
+  .modal-xl {
+    --bs-modal-width: 1140px;
+  }
+}
+.modal-fullscreen {
+  width: 100vw;
+  max-width: none;
+  height: 100%;
+  margin: 0;
+}
+.modal-fullscreen .modal-content {
+  height: 100%;
+  border: 0;
+  border-radius: 0;
+}
+.modal-fullscreen .modal-header,
+.modal-fullscreen .modal-footer {
+  border-radius: 0;
+}
+.modal-fullscreen .modal-body {
+  overflow-y: auto;
+}
+
+@media (max-width: 575.98px) {
+  .modal-fullscreen-sm-down {
+    width: 100vw;
+    max-width: none;
+    height: 100%;
+    margin: 0;
+  }
+  .modal-fullscreen-sm-down .modal-content {
+    height: 100%;
+    border: 0;
+    border-radius: 0;
+  }
+  .modal-fullscreen-sm-down .modal-header,
+  .modal-fullscreen-sm-down .modal-footer {
+    border-radius: 0;
+  }
+  .modal-fullscreen-sm-down .modal-body {
+    overflow-y: auto;
+  }
+}
+@media (max-width: 767.98px) {
+  .modal-fullscreen-md-down {
+    width: 100vw;
+    max-width: none;
+    height: 100%;
+    margin: 0;
+  }
+  .modal-fullscreen-md-down .modal-content {
+    height: 100%;
+    border: 0;
+    border-radius: 0;
+  }
+  .modal-fullscreen-md-down .modal-header,
+  .modal-fullscreen-md-down .modal-footer {
+    border-radius: 0;
+  }
+  .modal-fullscreen-md-down .modal-body {
+    overflow-y: auto;
+  }
+}
+@media (max-width: 991.98px) {
+  .modal-fullscreen-lg-down {
+    width: 100vw;
+    max-width: none;
+    height: 100%;
+    margin: 0;
+  }
+  .modal-fullscreen-lg-down .modal-content {
+    height: 100%;
+    border: 0;
+    border-radius: 0;
+  }
+  .modal-fullscreen-lg-down .modal-header,
+  .modal-fullscreen-lg-down .modal-footer {
+    border-radius: 0;
+  }
+  .modal-fullscreen-lg-down .modal-body {
+    overflow-y: auto;
+  }
+}
+@media (max-width: 1199.98px) {
+  .modal-fullscreen-xl-down {
+    width: 100vw;
+    max-width: none;
+    height: 100%;
+    margin: 0;
+  }
+  .modal-fullscreen-xl-down .modal-content {
+    height: 100%;
+    border: 0;
+    border-radius: 0;
+  }
+  .modal-fullscreen-xl-down .modal-header,
+  .modal-fullscreen-xl-down .modal-footer {
+    border-radius: 0;
+  }
+  .modal-fullscreen-xl-down .modal-body {
+    overflow-y: auto;
+  }
+}
+@media (max-width: 1399.98px) {
+  .modal-fullscreen-xxl-down {
+    width: 100vw;
+    max-width: none;
+    height: 100%;
+    margin: 0;
+  }
+  .modal-fullscreen-xxl-down .modal-content {
+    height: 100%;
+    border: 0;
+    border-radius: 0;
+  }
+  .modal-fullscreen-xxl-down .modal-header,
+  .modal-fullscreen-xxl-down .modal-footer {
+    border-radius: 0;
+  }
+  .modal-fullscreen-xxl-down .modal-body {
+    overflow-y: auto;
+  }
+}
+.tooltip {
+  --bs-tooltip-zindex: 1080;
+  --bs-tooltip-max-width: 200px;
+  --bs-tooltip-padding-x: 0.5rem;
+  --bs-tooltip-padding-y: 0.25rem;
+  --bs-tooltip-margin: ;
+  --bs-tooltip-font-size: 0.875rem;
+  --bs-tooltip-color: var(--bs-body-bg);
+  --bs-tooltip-bg: var(--bs-emphasis-color);
+  --bs-tooltip-border-radius: var(--bs-border-radius);
+  --bs-tooltip-opacity: 0.9;
+  --bs-tooltip-arrow-width: 0.8rem;
+  --bs-tooltip-arrow-height: 0.4rem;
+  z-index: var(--bs-tooltip-zindex);
+  display: block;
+  margin: var(--bs-tooltip-margin);
+  font-family: var(--bs-font-sans-serif);
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.5;
+  text-align: left;
+  text-align: start;
+  text-decoration: none;
+  text-shadow: none;
+  text-transform: none;
+  letter-spacing: normal;
+  word-break: normal;
+  white-space: normal;
+  word-spacing: normal;
+  line-break: auto;
+  font-size: var(--bs-tooltip-font-size);
+  word-wrap: break-word;
+  opacity: 0;
+}
+.tooltip.show {
+  opacity: var(--bs-tooltip-opacity);
+}
+.tooltip .tooltip-arrow {
+  display: block;
+  width: var(--bs-tooltip-arrow-width);
+  height: var(--bs-tooltip-arrow-height);
+}
+.tooltip .tooltip-arrow::before {
+  position: absolute;
+  content: "";
+  border-color: transparent;
+  border-style: solid;
+}
+
+.bs-tooltip-top .tooltip-arrow, .bs-tooltip-auto[data-popper-placement^=top] .tooltip-arrow {
+  bottom: calc(-1 * var(--bs-tooltip-arrow-height));
+}
+.bs-tooltip-top .tooltip-arrow::before, .bs-tooltip-auto[data-popper-placement^=top] .tooltip-arrow::before {
+  top: -1px;
+  border-width: var(--bs-tooltip-arrow-height) calc(var(--bs-tooltip-arrow-width) * 0.5) 0;
+  border-top-color: var(--bs-tooltip-bg);
+}
+
+/* rtl:begin:ignore */
+.bs-tooltip-end .tooltip-arrow, .bs-tooltip-auto[data-popper-placement^=right] .tooltip-arrow {
+  left: calc(-1 * var(--bs-tooltip-arrow-height));
+  width: var(--bs-tooltip-arrow-height);
+  height: var(--bs-tooltip-arrow-width);
+}
+.bs-tooltip-end .tooltip-arrow::before, .bs-tooltip-auto[data-popper-placement^=right] .tooltip-arrow::before {
+  right: -1px;
+  border-width: calc(var(--bs-tooltip-arrow-width) * 0.5) var(--bs-tooltip-arrow-height) calc(var(--bs-tooltip-arrow-width) * 0.5) 0;
+  border-right-color: var(--bs-tooltip-bg);
+}
+
+/* rtl:end:ignore */
+.bs-tooltip-bottom .tooltip-arrow, .bs-tooltip-auto[data-popper-placement^=bottom] .tooltip-arrow {
+  top: calc(-1 * var(--bs-tooltip-arrow-height));
+}
+.bs-tooltip-bottom .tooltip-arrow::before, .bs-tooltip-auto[data-popper-placement^=bottom] .tooltip-arrow::before {
+  bottom: -1px;
+  border-width: 0 calc(var(--bs-tooltip-arrow-width) * 0.5) var(--bs-tooltip-arrow-height);
+  border-bottom-color: var(--bs-tooltip-bg);
+}
+
+/* rtl:begin:ignore */
+.bs-tooltip-start .tooltip-arrow, .bs-tooltip-auto[data-popper-placement^=left] .tooltip-arrow {
+  right: calc(-1 * var(--bs-tooltip-arrow-height));
+  width: var(--bs-tooltip-arrow-height);
+  height: var(--bs-tooltip-arrow-width);
+}
+.bs-tooltip-start .tooltip-arrow::before, .bs-tooltip-auto[data-popper-placement^=left] .tooltip-arrow::before {
+  left: -1px;
+  border-width: calc(var(--bs-tooltip-arrow-width) * 0.5) 0 calc(var(--bs-tooltip-arrow-width) * 0.5) var(--bs-tooltip-arrow-height);
+  border-left-color: var(--bs-tooltip-bg);
+}
+
+/* rtl:end:ignore */
+.tooltip-inner {
+  max-width: var(--bs-tooltip-max-width);
+  padding: var(--bs-tooltip-padding-y) var(--bs-tooltip-padding-x);
+  color: var(--bs-tooltip-color);
+  text-align: center;
+  background-color: var(--bs-tooltip-bg);
+  border-radius: var(--bs-tooltip-border-radius);
+}
+
+.popover {
+  --bs-popover-zindex: 1070;
+  --bs-popover-max-width: 276px;
+  --bs-popover-font-size: 0.875rem;
+  --bs-popover-bg: var(--bs-body-bg);
+  --bs-popover-border-width: var(--bs-border-width);
+  --bs-popover-border-color: var(--bs-border-color-translucent);
+  --bs-popover-border-radius: var(--bs-border-radius-lg);
+  --bs-popover-inner-border-radius: calc(var(--bs-border-radius-lg) - var(--bs-border-width));
+  --bs-popover-box-shadow: var(--bs-box-shadow);
+  --bs-popover-header-padding-x: 1rem;
+  --bs-popover-header-padding-y: 0.5rem;
+  --bs-popover-header-font-size: 1rem;
+  --bs-popover-header-color: inherit;
+  --bs-popover-header-bg: var(--bs-secondary-bg);
+  --bs-popover-body-padding-x: 1rem;
+  --bs-popover-body-padding-y: 1rem;
+  --bs-popover-body-color: var(--bs-body-color);
+  --bs-popover-arrow-width: 1rem;
+  --bs-popover-arrow-height: 0.5rem;
+  --bs-popover-arrow-border: var(--bs-popover-border-color);
+  z-index: var(--bs-popover-zindex);
+  display: block;
+  max-width: var(--bs-popover-max-width);
+  font-family: var(--bs-font-sans-serif);
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.5;
+  text-align: left;
+  text-align: start;
+  text-decoration: none;
+  text-shadow: none;
+  text-transform: none;
+  letter-spacing: normal;
+  word-break: normal;
+  white-space: normal;
+  word-spacing: normal;
+  line-break: auto;
+  font-size: var(--bs-popover-font-size);
+  word-wrap: break-word;
+  background-color: var(--bs-popover-bg);
+  background-clip: padding-box;
+  border: var(--bs-popover-border-width) solid var(--bs-popover-border-color);
+  border-radius: var(--bs-popover-border-radius);
+}
+.popover .popover-arrow {
+  display: block;
+  width: var(--bs-popover-arrow-width);
+  height: var(--bs-popover-arrow-height);
+}
+.popover .popover-arrow::before, .popover .popover-arrow::after {
+  position: absolute;
+  display: block;
+  content: "";
+  border-color: transparent;
+  border-style: solid;
+  border-width: 0;
+}
+
+.bs-popover-top > .popover-arrow, .bs-popover-auto[data-popper-placement^=top] > .popover-arrow {
+  bottom: calc(-1 * (var(--bs-popover-arrow-height)) - var(--bs-popover-border-width));
+}
+.bs-popover-top > .popover-arrow::before, .bs-popover-auto[data-popper-placement^=top] > .popover-arrow::before, .bs-popover-top > .popover-arrow::after, .bs-popover-auto[data-popper-placement^=top] > .popover-arrow::after {
+  border-width: var(--bs-popover-arrow-height) calc(var(--bs-popover-arrow-width) * 0.5) 0;
+}
+.bs-popover-top > .popover-arrow::before, .bs-popover-auto[data-popper-placement^=top] > .popover-arrow::before {
+  bottom: 0;
+  border-top-color: var(--bs-popover-arrow-border);
+}
+.bs-popover-top > .popover-arrow::after, .bs-popover-auto[data-popper-placement^=top] > .popover-arrow::after {
+  bottom: var(--bs-popover-border-width);
+  border-top-color: var(--bs-popover-bg);
+}
+
+/* rtl:begin:ignore */
+.bs-popover-end > .popover-arrow, .bs-popover-auto[data-popper-placement^=right] > .popover-arrow {
+  left: calc(-1 * (var(--bs-popover-arrow-height)) - var(--bs-popover-border-width));
+  width: var(--bs-popover-arrow-height);
+  height: var(--bs-popover-arrow-width);
+}
+.bs-popover-end > .popover-arrow::before, .bs-popover-auto[data-popper-placement^=right] > .popover-arrow::before, .bs-popover-end > .popover-arrow::after, .bs-popover-auto[data-popper-placement^=right] > .popover-arrow::after {
+  border-width: calc(var(--bs-popover-arrow-width) * 0.5) var(--bs-popover-arrow-height) calc(var(--bs-popover-arrow-width) * 0.5) 0;
+}
+.bs-popover-end > .popover-arrow::before, .bs-popover-auto[data-popper-placement^=right] > .popover-arrow::before {
+  left: 0;
+  border-right-color: var(--bs-popover-arrow-border);
+}
+.bs-popover-end > .popover-arrow::after, .bs-popover-auto[data-popper-placement^=right] > .popover-arrow::after {
+  left: var(--bs-popover-border-width);
+  border-right-color: var(--bs-popover-bg);
+}
+
+/* rtl:end:ignore */
+.bs-popover-bottom > .popover-arrow, .bs-popover-auto[data-popper-placement^=bottom] > .popover-arrow {
+  top: calc(-1 * (var(--bs-popover-arrow-height)) - var(--bs-popover-border-width));
+}
+.bs-popover-bottom > .popover-arrow::before, .bs-popover-auto[data-popper-placement^=bottom] > .popover-arrow::before, .bs-popover-bottom > .popover-arrow::after, .bs-popover-auto[data-popper-placement^=bottom] > .popover-arrow::after {
+  border-width: 0 calc(var(--bs-popover-arrow-width) * 0.5) var(--bs-popover-arrow-height);
+}
+.bs-popover-bottom > .popover-arrow::before, .bs-popover-auto[data-popper-placement^=bottom] > .popover-arrow::before {
+  top: 0;
+  border-bottom-color: var(--bs-popover-arrow-border);
+}
+.bs-popover-bottom > .popover-arrow::after, .bs-popover-auto[data-popper-placement^=bottom] > .popover-arrow::after {
+  top: var(--bs-popover-border-width);
+  border-bottom-color: var(--bs-popover-bg);
+}
+.bs-popover-bottom .popover-header::before, .bs-popover-auto[data-popper-placement^=bottom] .popover-header::before {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  display: block;
+  width: var(--bs-popover-arrow-width);
+  margin-left: calc(-0.5 * var(--bs-popover-arrow-width));
+  content: "";
+  border-bottom: var(--bs-popover-border-width) solid var(--bs-popover-header-bg);
+}
+
+/* rtl:begin:ignore */
+.bs-popover-start > .popover-arrow, .bs-popover-auto[data-popper-placement^=left] > .popover-arrow {
+  right: calc(-1 * (var(--bs-popover-arrow-height)) - var(--bs-popover-border-width));
+  width: var(--bs-popover-arrow-height);
+  height: var(--bs-popover-arrow-width);
+}
+.bs-popover-start > .popover-arrow::before, .bs-popover-auto[data-popper-placement^=left] > .popover-arrow::before, .bs-popover-start > .popover-arrow::after, .bs-popover-auto[data-popper-placement^=left] > .popover-arrow::after {
+  border-width: calc(var(--bs-popover-arrow-width) * 0.5) 0 calc(var(--bs-popover-arrow-width) * 0.5) var(--bs-popover-arrow-height);
+}
+.bs-popover-start > .popover-arrow::before, .bs-popover-auto[data-popper-placement^=left] > .popover-arrow::before {
+  right: 0;
+  border-left-color: var(--bs-popover-arrow-border);
+}
+.bs-popover-start > .popover-arrow::after, .bs-popover-auto[data-popper-placement^=left] > .popover-arrow::after {
+  right: var(--bs-popover-border-width);
+  border-left-color: var(--bs-popover-bg);
+}
+
+/* rtl:end:ignore */
+.popover-header {
+  padding: var(--bs-popover-header-padding-y) var(--bs-popover-header-padding-x);
+  margin-bottom: 0;
+  font-size: var(--bs-popover-header-font-size);
+  color: var(--bs-popover-header-color);
+  background-color: var(--bs-popover-header-bg);
+  border-bottom: var(--bs-popover-border-width) solid var(--bs-popover-border-color);
+  border-top-left-radius: var(--bs-popover-inner-border-radius);
+  border-top-right-radius: var(--bs-popover-inner-border-radius);
+}
+.popover-header:empty {
+  display: none;
+}
+
+.popover-body {
+  padding: var(--bs-popover-body-padding-y) var(--bs-popover-body-padding-x);
+  color: var(--bs-popover-body-color);
+}
+
+.carousel {
+  position: relative;
+}
+
+.carousel.pointer-event {
+  touch-action: pan-y;
+}
+
+.carousel-inner {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+}
+.carousel-inner::after {
+  display: block;
+  clear: both;
+  content: "";
+}
+
+.carousel-item {
+  position: relative;
+  display: none;
+  float: left;
+  width: 100%;
+  margin-right: -100%;
+  backface-visibility: hidden;
+  transition: transform 0.6s ease-in-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .carousel-item {
+    transition: none;
+  }
+}
+
+.carousel-item.active,
+.carousel-item-next,
+.carousel-item-prev {
+  display: block;
+}
+
+.carousel-item-next:not(.carousel-item-start),
+.active.carousel-item-end {
+  transform: translateX(100%);
+}
+
+.carousel-item-prev:not(.carousel-item-end),
+.active.carousel-item-start {
+  transform: translateX(-100%);
+}
+
+.carousel-fade .carousel-item {
+  opacity: 0;
+  transition-property: opacity;
+  transform: none;
+}
+.carousel-fade .carousel-item.active,
+.carousel-fade .carousel-item-next.carousel-item-start,
+.carousel-fade .carousel-item-prev.carousel-item-end {
+  z-index: 1;
+  opacity: 1;
+}
+.carousel-fade .active.carousel-item-start,
+.carousel-fade .active.carousel-item-end {
+  z-index: 0;
+  opacity: 0;
+  transition: opacity 0s 0.6s;
+}
+@media (prefers-reduced-motion: reduce) {
+  .carousel-fade .active.carousel-item-start,
+  .carousel-fade .active.carousel-item-end {
+    transition: none;
+  }
+}
+
+.carousel-control-prev,
+.carousel-control-next {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 15%;
+  padding: 0;
+  color: #ffffff;
+  text-align: center;
+  background: none;
+  filter: var(--bs-carousel-control-icon-filter);
+  border: 0;
+  opacity: 0.5;
+  transition: opacity 0.15s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  .carousel-control-prev,
+  .carousel-control-next {
+    transition: none;
+  }
+}
+.carousel-control-prev:hover, .carousel-control-prev:focus,
+.carousel-control-next:hover,
+.carousel-control-next:focus {
+  color: #ffffff;
+  text-decoration: none;
+  outline: 0;
+  opacity: 0.9;
+}
+
+.carousel-control-prev {
+  left: 0;
+}
+
+.carousel-control-next {
+  right: 0;
+}
+
+.carousel-control-prev-icon,
+.carousel-control-next-icon {
+  display: inline-block;
+  width: 2rem;
+  height: 2rem;
+  background-repeat: no-repeat;
+  background-position: 50%;
+  background-size: 100% 100%;
+}
+
+.carousel-control-prev-icon {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23ffffff'%3e%3cpath d='M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0'/%3e%3c/svg%3e") /*rtl:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23ffffff'%3e%3cpath d='M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708'/%3e%3c/svg%3e")*/;
+}
+
+.carousel-control-next-icon {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23ffffff'%3e%3cpath d='M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708'/%3e%3c/svg%3e") /*rtl:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23ffffff'%3e%3cpath d='M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0'/%3e%3c/svg%3e")*/;
+}
+
+.carousel-indicators {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 2;
+  display: flex;
+  justify-content: center;
+  padding: 0;
+  margin-right: 15%;
+  margin-bottom: 1rem;
+  margin-left: 15%;
+}
+.carousel-indicators [data-bs-target] {
+  box-sizing: content-box;
+  flex: 0 1 auto;
+  width: 30px;
+  height: 3px;
+  padding: 0;
+  margin-right: 3px;
+  margin-left: 3px;
+  text-indent: -999px;
+  cursor: pointer;
+  background-color: var(--bs-carousel-indicator-active-bg);
+  background-clip: padding-box;
+  border: 0;
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+  opacity: 0.5;
+  transition: opacity 0.6s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  .carousel-indicators [data-bs-target] {
+    transition: none;
+  }
+}
+.carousel-indicators .active {
+  opacity: 1;
+}
+
+.carousel-caption {
+  position: absolute;
+  right: 15%;
+  bottom: 1.25rem;
+  left: 15%;
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
+  color: var(--bs-carousel-caption-color);
+  text-align: center;
+}
+
+.carousel-dark {
+  --bs-carousel-indicator-active-bg: #000000;
+  --bs-carousel-caption-color: #000000;
+  --bs-carousel-control-icon-filter: invert(1) grayscale(100);
+}
+
+:root,
+[data-bs-theme=light] {
+  --bs-carousel-indicator-active-bg: #ffffff;
+  --bs-carousel-caption-color: #ffffff;
+  --bs-carousel-control-icon-filter: ;
+}
+
+[data-bs-theme=dark] {
+  --bs-carousel-indicator-active-bg: #000000;
+  --bs-carousel-caption-color: #000000;
+  --bs-carousel-control-icon-filter: invert(1) grayscale(100);
+}
+
+.spinner-grow,
+.spinner-border {
+  display: inline-block;
+  width: var(--bs-spinner-width);
+  height: var(--bs-spinner-height);
+  vertical-align: var(--bs-spinner-vertical-align);
+  border-radius: 50%;
+  animation: var(--bs-spinner-animation-speed) linear infinite var(--bs-spinner-animation-name);
+}
+
+@keyframes spinner-border {
+  to {
+    transform: rotate(360deg) /* rtl:ignore */;
+  }
+}
+.spinner-border {
+  --bs-spinner-width: 2rem;
+  --bs-spinner-height: 2rem;
+  --bs-spinner-vertical-align: -0.125em;
+  --bs-spinner-border-width: 0.25em;
+  --bs-spinner-animation-speed: 0.75s;
+  --bs-spinner-animation-name: spinner-border;
+  border: var(--bs-spinner-border-width) solid currentcolor;
+  border-right-color: transparent;
+}
+
+.spinner-border-sm {
+  --bs-spinner-width: 1rem;
+  --bs-spinner-height: 1rem;
+  --bs-spinner-border-width: 0.2em;
+}
+
+@keyframes spinner-grow {
+  0% {
+    transform: scale(0);
+  }
+  50% {
+    opacity: 1;
+    transform: none;
+  }
+}
+.spinner-grow {
+  --bs-spinner-width: 2rem;
+  --bs-spinner-height: 2rem;
+  --bs-spinner-vertical-align: -0.125em;
+  --bs-spinner-animation-speed: 0.75s;
+  --bs-spinner-animation-name: spinner-grow;
+  background-color: currentcolor;
+  opacity: 0;
+}
+
+.spinner-grow-sm {
+  --bs-spinner-width: 1rem;
+  --bs-spinner-height: 1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner-border,
+  .spinner-grow {
+    --bs-spinner-animation-speed: 1.5s;
+  }
+}
+.offcanvas, .offcanvas-xxl, .offcanvas-xl, .offcanvas-lg, .offcanvas-md, .offcanvas-sm {
+  --bs-offcanvas-zindex: 1045;
+  --bs-offcanvas-width: 400px;
+  --bs-offcanvas-height: 30vh;
+  --bs-offcanvas-padding-x: 1rem;
+  --bs-offcanvas-padding-y: 1rem;
+  --bs-offcanvas-color: var(--bs-body-color);
+  --bs-offcanvas-bg: var(--bs-body-bg);
+  --bs-offcanvas-border-width: var(--bs-border-width);
+  --bs-offcanvas-border-color: var(--bs-border-color-translucent);
+  --bs-offcanvas-box-shadow: var(--bs-box-shadow-sm);
+  --bs-offcanvas-transition: transform 0.3s ease-in-out;
+  --bs-offcanvas-title-line-height: 1.5;
+}
+
+@media (max-width: 575.98px) {
+  .offcanvas-sm {
+    position: fixed;
+    bottom: 0;
+    z-index: var(--bs-offcanvas-zindex);
+    display: flex;
+    flex-direction: column;
+    max-width: 100%;
+    color: var(--bs-offcanvas-color);
+    visibility: hidden;
+    background-color: var(--bs-offcanvas-bg);
+    background-clip: padding-box;
+    outline: 0;
+    transition: var(--bs-offcanvas-transition);
+  }
+}
+@media (max-width: 575.98px) and (prefers-reduced-motion: reduce) {
+  .offcanvas-sm {
+    transition: none;
+  }
+}
+@media (max-width: 575.98px) {
+  .offcanvas-sm.offcanvas-start {
+    top: 0;
+    left: 0;
+    width: var(--bs-offcanvas-width);
+    border-right: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateX(-100%);
+  }
+  .offcanvas-sm.offcanvas-end {
+    top: 0;
+    right: 0;
+    width: var(--bs-offcanvas-width);
+    border-left: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateX(100%);
+  }
+  .offcanvas-sm.offcanvas-top {
+    top: 0;
+    right: 0;
+    left: 0;
+    height: var(--bs-offcanvas-height);
+    max-height: 100%;
+    border-bottom: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateY(-100%);
+  }
+  .offcanvas-sm.offcanvas-bottom {
+    right: 0;
+    left: 0;
+    height: var(--bs-offcanvas-height);
+    max-height: 100%;
+    border-top: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateY(100%);
+  }
+  .offcanvas-sm.showing, .offcanvas-sm.show:not(.hiding) {
+    transform: none;
+  }
+  .offcanvas-sm.showing, .offcanvas-sm.hiding, .offcanvas-sm.show {
+    visibility: visible;
+  }
+}
+@media (min-width: 576px) {
+  .offcanvas-sm {
+    --bs-offcanvas-height: auto;
+    --bs-offcanvas-border-width: 0;
+    background-color: transparent !important;
+  }
+  .offcanvas-sm .offcanvas-header {
+    display: none;
+  }
+  .offcanvas-sm .offcanvas-body {
+    display: flex;
+    flex-grow: 0;
+    padding: 0;
+    overflow-y: visible;
+    background-color: transparent !important;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .offcanvas-md {
+    position: fixed;
+    bottom: 0;
+    z-index: var(--bs-offcanvas-zindex);
+    display: flex;
+    flex-direction: column;
+    max-width: 100%;
+    color: var(--bs-offcanvas-color);
+    visibility: hidden;
+    background-color: var(--bs-offcanvas-bg);
+    background-clip: padding-box;
+    outline: 0;
+    transition: var(--bs-offcanvas-transition);
+  }
+}
+@media (max-width: 767.98px) and (prefers-reduced-motion: reduce) {
+  .offcanvas-md {
+    transition: none;
+  }
+}
+@media (max-width: 767.98px) {
+  .offcanvas-md.offcanvas-start {
+    top: 0;
+    left: 0;
+    width: var(--bs-offcanvas-width);
+    border-right: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateX(-100%);
+  }
+  .offcanvas-md.offcanvas-end {
+    top: 0;
+    right: 0;
+    width: var(--bs-offcanvas-width);
+    border-left: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateX(100%);
+  }
+  .offcanvas-md.offcanvas-top {
+    top: 0;
+    right: 0;
+    left: 0;
+    height: var(--bs-offcanvas-height);
+    max-height: 100%;
+    border-bottom: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateY(-100%);
+  }
+  .offcanvas-md.offcanvas-bottom {
+    right: 0;
+    left: 0;
+    height: var(--bs-offcanvas-height);
+    max-height: 100%;
+    border-top: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateY(100%);
+  }
+  .offcanvas-md.showing, .offcanvas-md.show:not(.hiding) {
+    transform: none;
+  }
+  .offcanvas-md.showing, .offcanvas-md.hiding, .offcanvas-md.show {
+    visibility: visible;
+  }
+}
+@media (min-width: 768px) {
+  .offcanvas-md {
+    --bs-offcanvas-height: auto;
+    --bs-offcanvas-border-width: 0;
+    background-color: transparent !important;
+  }
+  .offcanvas-md .offcanvas-header {
+    display: none;
+  }
+  .offcanvas-md .offcanvas-body {
+    display: flex;
+    flex-grow: 0;
+    padding: 0;
+    overflow-y: visible;
+    background-color: transparent !important;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .offcanvas-lg {
+    position: fixed;
+    bottom: 0;
+    z-index: var(--bs-offcanvas-zindex);
+    display: flex;
+    flex-direction: column;
+    max-width: 100%;
+    color: var(--bs-offcanvas-color);
+    visibility: hidden;
+    background-color: var(--bs-offcanvas-bg);
+    background-clip: padding-box;
+    outline: 0;
+    transition: var(--bs-offcanvas-transition);
+  }
+}
+@media (max-width: 991.98px) and (prefers-reduced-motion: reduce) {
+  .offcanvas-lg {
+    transition: none;
+  }
+}
+@media (max-width: 991.98px) {
+  .offcanvas-lg.offcanvas-start {
+    top: 0;
+    left: 0;
+    width: var(--bs-offcanvas-width);
+    border-right: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateX(-100%);
+  }
+  .offcanvas-lg.offcanvas-end {
+    top: 0;
+    right: 0;
+    width: var(--bs-offcanvas-width);
+    border-left: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateX(100%);
+  }
+  .offcanvas-lg.offcanvas-top {
+    top: 0;
+    right: 0;
+    left: 0;
+    height: var(--bs-offcanvas-height);
+    max-height: 100%;
+    border-bottom: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateY(-100%);
+  }
+  .offcanvas-lg.offcanvas-bottom {
+    right: 0;
+    left: 0;
+    height: var(--bs-offcanvas-height);
+    max-height: 100%;
+    border-top: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateY(100%);
+  }
+  .offcanvas-lg.showing, .offcanvas-lg.show:not(.hiding) {
+    transform: none;
+  }
+  .offcanvas-lg.showing, .offcanvas-lg.hiding, .offcanvas-lg.show {
+    visibility: visible;
+  }
+}
+@media (min-width: 992px) {
+  .offcanvas-lg {
+    --bs-offcanvas-height: auto;
+    --bs-offcanvas-border-width: 0;
+    background-color: transparent !important;
+  }
+  .offcanvas-lg .offcanvas-header {
+    display: none;
+  }
+  .offcanvas-lg .offcanvas-body {
+    display: flex;
+    flex-grow: 0;
+    padding: 0;
+    overflow-y: visible;
+    background-color: transparent !important;
+  }
+}
+
+@media (max-width: 1199.98px) {
+  .offcanvas-xl {
+    position: fixed;
+    bottom: 0;
+    z-index: var(--bs-offcanvas-zindex);
+    display: flex;
+    flex-direction: column;
+    max-width: 100%;
+    color: var(--bs-offcanvas-color);
+    visibility: hidden;
+    background-color: var(--bs-offcanvas-bg);
+    background-clip: padding-box;
+    outline: 0;
+    transition: var(--bs-offcanvas-transition);
+  }
+}
+@media (max-width: 1199.98px) and (prefers-reduced-motion: reduce) {
+  .offcanvas-xl {
+    transition: none;
+  }
+}
+@media (max-width: 1199.98px) {
+  .offcanvas-xl.offcanvas-start {
+    top: 0;
+    left: 0;
+    width: var(--bs-offcanvas-width);
+    border-right: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateX(-100%);
+  }
+  .offcanvas-xl.offcanvas-end {
+    top: 0;
+    right: 0;
+    width: var(--bs-offcanvas-width);
+    border-left: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateX(100%);
+  }
+  .offcanvas-xl.offcanvas-top {
+    top: 0;
+    right: 0;
+    left: 0;
+    height: var(--bs-offcanvas-height);
+    max-height: 100%;
+    border-bottom: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateY(-100%);
+  }
+  .offcanvas-xl.offcanvas-bottom {
+    right: 0;
+    left: 0;
+    height: var(--bs-offcanvas-height);
+    max-height: 100%;
+    border-top: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateY(100%);
+  }
+  .offcanvas-xl.showing, .offcanvas-xl.show:not(.hiding) {
+    transform: none;
+  }
+  .offcanvas-xl.showing, .offcanvas-xl.hiding, .offcanvas-xl.show {
+    visibility: visible;
+  }
+}
+@media (min-width: 1200px) {
+  .offcanvas-xl {
+    --bs-offcanvas-height: auto;
+    --bs-offcanvas-border-width: 0;
+    background-color: transparent !important;
+  }
+  .offcanvas-xl .offcanvas-header {
+    display: none;
+  }
+  .offcanvas-xl .offcanvas-body {
+    display: flex;
+    flex-grow: 0;
+    padding: 0;
+    overflow-y: visible;
+    background-color: transparent !important;
+  }
+}
+
+@media (max-width: 1399.98px) {
+  .offcanvas-xxl {
+    position: fixed;
+    bottom: 0;
+    z-index: var(--bs-offcanvas-zindex);
+    display: flex;
+    flex-direction: column;
+    max-width: 100%;
+    color: var(--bs-offcanvas-color);
+    visibility: hidden;
+    background-color: var(--bs-offcanvas-bg);
+    background-clip: padding-box;
+    outline: 0;
+    transition: var(--bs-offcanvas-transition);
+  }
+}
+@media (max-width: 1399.98px) and (prefers-reduced-motion: reduce) {
+  .offcanvas-xxl {
+    transition: none;
+  }
+}
+@media (max-width: 1399.98px) {
+  .offcanvas-xxl.offcanvas-start {
+    top: 0;
+    left: 0;
+    width: var(--bs-offcanvas-width);
+    border-right: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateX(-100%);
+  }
+  .offcanvas-xxl.offcanvas-end {
+    top: 0;
+    right: 0;
+    width: var(--bs-offcanvas-width);
+    border-left: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateX(100%);
+  }
+  .offcanvas-xxl.offcanvas-top {
+    top: 0;
+    right: 0;
+    left: 0;
+    height: var(--bs-offcanvas-height);
+    max-height: 100%;
+    border-bottom: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateY(-100%);
+  }
+  .offcanvas-xxl.offcanvas-bottom {
+    right: 0;
+    left: 0;
+    height: var(--bs-offcanvas-height);
+    max-height: 100%;
+    border-top: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+    transform: translateY(100%);
+  }
+  .offcanvas-xxl.showing, .offcanvas-xxl.show:not(.hiding) {
+    transform: none;
+  }
+  .offcanvas-xxl.showing, .offcanvas-xxl.hiding, .offcanvas-xxl.show {
+    visibility: visible;
+  }
+}
+@media (min-width: 1400px) {
+  .offcanvas-xxl {
+    --bs-offcanvas-height: auto;
+    --bs-offcanvas-border-width: 0;
+    background-color: transparent !important;
+  }
+  .offcanvas-xxl .offcanvas-header {
+    display: none;
+  }
+  .offcanvas-xxl .offcanvas-body {
+    display: flex;
+    flex-grow: 0;
+    padding: 0;
+    overflow-y: visible;
+    background-color: transparent !important;
+  }
+}
+
+.offcanvas {
+  position: fixed;
+  bottom: 0;
+  z-index: var(--bs-offcanvas-zindex);
+  display: flex;
+  flex-direction: column;
+  max-width: 100%;
+  color: var(--bs-offcanvas-color);
+  visibility: hidden;
+  background-color: var(--bs-offcanvas-bg);
+  background-clip: padding-box;
+  outline: 0;
+  transition: var(--bs-offcanvas-transition);
+}
+@media (prefers-reduced-motion: reduce) {
+  .offcanvas {
+    transition: none;
+  }
+}
+.offcanvas.offcanvas-start {
+  top: 0;
+  left: 0;
+  width: var(--bs-offcanvas-width);
+  border-right: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+  transform: translateX(-100%);
+}
+.offcanvas.offcanvas-end {
+  top: 0;
+  right: 0;
+  width: var(--bs-offcanvas-width);
+  border-left: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+  transform: translateX(100%);
+}
+.offcanvas.offcanvas-top {
+  top: 0;
+  right: 0;
+  left: 0;
+  height: var(--bs-offcanvas-height);
+  max-height: 100%;
+  border-bottom: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+  transform: translateY(-100%);
+}
+.offcanvas.offcanvas-bottom {
+  right: 0;
+  left: 0;
+  height: var(--bs-offcanvas-height);
+  max-height: 100%;
+  border-top: var(--bs-offcanvas-border-width) solid var(--bs-offcanvas-border-color);
+  transform: translateY(100%);
+}
+.offcanvas.showing, .offcanvas.show:not(.hiding) {
+  transform: none;
+}
+.offcanvas.showing, .offcanvas.hiding, .offcanvas.show {
+  visibility: visible;
+}
+
+.offcanvas-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1040;
+  width: 100vw;
+  height: 100vh;
+  background-color: #000000;
+}
+.offcanvas-backdrop.fade {
+  opacity: 0;
+}
+.offcanvas-backdrop.show {
+  opacity: 0.5;
+}
+
+.offcanvas-header {
+  display: flex;
+  align-items: center;
+  padding: var(--bs-offcanvas-padding-y) var(--bs-offcanvas-padding-x);
+}
+.offcanvas-header .btn-close {
+  padding: calc(var(--bs-offcanvas-padding-y) * 0.5) calc(var(--bs-offcanvas-padding-x) * 0.5);
+  margin-top: calc(-0.5 * var(--bs-offcanvas-padding-y));
+  margin-right: calc(-0.5 * var(--bs-offcanvas-padding-x));
+  margin-bottom: calc(-0.5 * var(--bs-offcanvas-padding-y));
+  margin-left: auto;
+}
+
+.offcanvas-title {
+  margin-bottom: 0;
+  line-height: var(--bs-offcanvas-title-line-height);
+}
+
+.offcanvas-body {
+  flex-grow: 1;
+  padding: var(--bs-offcanvas-padding-y) var(--bs-offcanvas-padding-x);
+  overflow-y: auto;
+}
+
+.placeholder {
+  display: inline-block;
+  min-height: 1em;
+  vertical-align: middle;
+  cursor: wait;
+  background-color: currentcolor;
+  opacity: 0.5;
+}
+.placeholder.btn::before {
+  display: inline-block;
+  content: "";
+}
+
+.placeholder-xs {
+  min-height: 0.6em;
+}
+
+.placeholder-sm {
+  min-height: 0.8em;
+}
+
+.placeholder-lg {
+  min-height: 1.2em;
+}
+
+.placeholder-glow .placeholder {
+  animation: placeholder-glow 2s ease-in-out infinite;
+}
+
+@keyframes placeholder-glow {
+  50% {
+    opacity: 0.2;
+  }
+}
+.placeholder-wave {
+  mask-image: linear-gradient(130deg, #000000 55%, rgba(0, 0, 0, 0.8) 75%, #000000 95%);
+  mask-size: 200% 100%;
+  animation: placeholder-wave 2s linear infinite;
+}
+
+@keyframes placeholder-wave {
+  100% {
+    mask-position: -200% 0%;
+  }
+}
+.clearfix::after {
+  display: block;
+  clear: both;
+  content: "";
+}
+
+.text-bg-primary {
+  color: #ffffff !important;
+  background-color: RGBA(var(--bs-primary-rgb), var(--bs-bg-opacity, 1)) !important;
+}
+
+.text-bg-secondary {
+  color: #ffffff !important;
+  background-color: RGBA(var(--bs-secondary-rgb), var(--bs-bg-opacity, 1)) !important;
+}
+
+.text-bg-success {
+  color: #ffffff !important;
+  background-color: RGBA(var(--bs-success-rgb), var(--bs-bg-opacity, 1)) !important;
+}
+
+.text-bg-info {
+  color: #000000 !important;
+  background-color: RGBA(var(--bs-info-rgb), var(--bs-bg-opacity, 1)) !important;
+}
+
+.text-bg-warning {
+  color: #000000 !important;
+  background-color: RGBA(var(--bs-warning-rgb), var(--bs-bg-opacity, 1)) !important;
+}
+
+.text-bg-danger {
+  color: #ffffff !important;
+  background-color: RGBA(var(--bs-danger-rgb), var(--bs-bg-opacity, 1)) !important;
+}
+
+.text-bg-light {
+  color: #000000 !important;
+  background-color: RGBA(var(--bs-light-rgb), var(--bs-bg-opacity, 1)) !important;
+}
+
+.text-bg-dark {
+  color: #ffffff !important;
+  background-color: RGBA(var(--bs-dark-rgb), var(--bs-bg-opacity, 1)) !important;
+}
+
+.link-primary {
+  color: RGBA(var(--bs-primary-rgb), var(--bs-link-opacity, 1)) !important;
+  text-decoration-color: RGBA(var(--bs-primary-rgb), var(--bs-link-underline-opacity, 1)) !important;
+}
+.link-primary:hover, .link-primary:focus {
+  color: RGBA(8, 20, 33, var(--bs-link-opacity, 1)) !important;
+  text-decoration-color: RGBA(8, 20, 33, var(--bs-link-underline-opacity, 1)) !important;
+}
+
+.link-secondary {
+  color: RGBA(var(--bs-secondary-rgb), var(--bs-link-opacity, 1)) !important;
+  text-decoration-color: RGBA(var(--bs-secondary-rgb), var(--bs-link-underline-opacity, 1)) !important;
+}
+.link-secondary:hover, .link-secondary:focus {
+  color: RGBA(16, 40, 66, var(--bs-link-opacity, 1)) !important;
+  text-decoration-color: RGBA(16, 40, 66, var(--bs-link-underline-opacity, 1)) !important;
+}
+
+.link-success {
+  color: RGBA(var(--bs-success-rgb), var(--bs-link-opacity, 1)) !important;
+  text-decoration-color: RGBA(var(--bs-success-rgb), var(--bs-link-underline-opacity, 1)) !important;
+}
+.link-success:hover, .link-success:focus {
+  color: RGBA(20, 108, 67, var(--bs-link-opacity, 1)) !important;
+  text-decoration-color: RGBA(20, 108, 67, var(--bs-link-underline-opacity, 1)) !important;
+}
+
+.link-info {
+  color: RGBA(var(--bs-info-rgb), var(--bs-link-opacity, 1)) !important;
+  text-decoration-color: RGBA(var(--bs-info-rgb), var(--bs-link-underline-opacity, 1)) !important;
+}
+.link-info:hover, .link-info:focus {
+  color: RGBA(61, 213, 243, var(--bs-link-opacity, 1)) !important;
+  text-decoration-color: RGBA(61, 213, 243, var(--bs-link-underline-opacity, 1)) !important;
+}
+
+.link-warning {
+  color: RGBA(var(--bs-warning-rgb), var(--bs-link-opacity, 1)) !important;
+  text-decoration-color: RGBA(var(--bs-warning-rgb), var(--bs-link-underline-opacity, 1)) !important;
+}
+.link-warning:hover, .link-warning:focus {
+  color: RGBA(255, 205, 57, var(--bs-link-opacity, 1)) !important;
+  text-decoration-color: RGBA(255, 205, 57, var(--bs-link-underline-opacity, 1)) !important;
+}
+
+.link-danger {
+  color: RGBA(var(--bs-danger-rgb), var(--bs-link-opacity, 1)) !important;
+  text-decoration-color: RGBA(var(--bs-danger-rgb), var(--bs-link-underline-opacity, 1)) !important;
+}
+.link-danger:hover, .link-danger:focus {
+  color: RGBA(166, 19, 24, var(--bs-link-opacity, 1)) !important;
+  text-decoration-color: RGBA(166, 19, 24, var(--bs-link-underline-opacity, 1)) !important;
+}
+
+.link-light {
+  color: RGBA(var(--bs-light-rgb), var(--bs-link-opacity, 1)) !important;
+  text-decoration-color: RGBA(var(--bs-light-rgb), var(--bs-link-underline-opacity, 1)) !important;
+}
+.link-light:hover, .link-light:focus {
+  color: RGBA(249, 250, 251, var(--bs-link-opacity, 1)) !important;
+  text-decoration-color: RGBA(249, 250, 251, var(--bs-link-underline-opacity, 1)) !important;
+}
+
+.link-dark {
+  color: RGBA(var(--bs-dark-rgb), var(--bs-link-opacity, 1)) !important;
+  text-decoration-color: RGBA(var(--bs-dark-rgb), var(--bs-link-underline-opacity, 1)) !important;
+}
+.link-dark:hover, .link-dark:focus {
+  color: RGBA(26, 30, 33, var(--bs-link-opacity, 1)) !important;
+  text-decoration-color: RGBA(26, 30, 33, var(--bs-link-underline-opacity, 1)) !important;
+}
+
+.link-body-emphasis {
+  color: RGBA(var(--bs-emphasis-color-rgb), var(--bs-link-opacity, 1)) !important;
+  text-decoration-color: RGBA(var(--bs-emphasis-color-rgb), var(--bs-link-underline-opacity, 1)) !important;
+}
+.link-body-emphasis:hover, .link-body-emphasis:focus {
+  color: RGBA(var(--bs-emphasis-color-rgb), var(--bs-link-opacity, 0.75)) !important;
+  text-decoration-color: RGBA(var(--bs-emphasis-color-rgb), var(--bs-link-underline-opacity, 0.75)) !important;
+}
+
+.focus-ring:focus {
+  outline: 0;
+  box-shadow: var(--bs-focus-ring-x, 0) var(--bs-focus-ring-y, 0) var(--bs-focus-ring-blur, 0) var(--bs-focus-ring-width) var(--bs-focus-ring-color);
+}
+
+.icon-link {
+  display: inline-flex;
+  gap: 0.375rem;
+  align-items: center;
+  text-decoration-color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 0.5));
+  text-underline-offset: 0.25em;
+  backface-visibility: hidden;
+}
+.icon-link > .bi {
+  flex-shrink: 0;
+  width: 1em;
+  height: 1em;
+  fill: currentcolor;
+  transition: 0.2s ease-in-out transform;
+}
+@media (prefers-reduced-motion: reduce) {
+  .icon-link > .bi {
+    transition: none;
+  }
+}
+
+.icon-link-hover:hover > .bi, .icon-link-hover:focus-visible > .bi {
+  transform: var(--bs-icon-link-transform, translate3d(0.25em, 0, 0));
+}
+
+.ratio {
+  position: relative;
+  width: 100%;
+}
+.ratio::before {
+  display: block;
+  padding-top: var(--bs-aspect-ratio);
+  content: "";
+}
+.ratio > * {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.ratio-1x1 {
+  --bs-aspect-ratio: 100%;
+}
+
+.ratio-4x3 {
+  --bs-aspect-ratio: 75%;
+}
+
+.ratio-16x9 {
+  --bs-aspect-ratio: 56.25%;
+}
+
+.ratio-21x9 {
+  --bs-aspect-ratio: 42.8571428571%;
+}
+
+.fixed-top {
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 1030;
+}
+
+.fixed-bottom {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1030;
+}
+
+.sticky-top {
+  position: sticky;
+  top: 0;
+  z-index: 1020;
+}
+
+.sticky-bottom {
+  position: sticky;
+  bottom: 0;
+  z-index: 1020;
+}
+
+@media (min-width: 576px) {
+  .sticky-sm-top {
+    position: sticky;
+    top: 0;
+    z-index: 1020;
+  }
+  .sticky-sm-bottom {
+    position: sticky;
+    bottom: 0;
+    z-index: 1020;
+  }
+}
+@media (min-width: 768px) {
+  .sticky-md-top {
+    position: sticky;
+    top: 0;
+    z-index: 1020;
+  }
+  .sticky-md-bottom {
+    position: sticky;
+    bottom: 0;
+    z-index: 1020;
+  }
+}
+@media (min-width: 992px) {
+  .sticky-lg-top {
+    position: sticky;
+    top: 0;
+    z-index: 1020;
+  }
+  .sticky-lg-bottom {
+    position: sticky;
+    bottom: 0;
+    z-index: 1020;
+  }
+}
+@media (min-width: 1200px) {
+  .sticky-xl-top {
+    position: sticky;
+    top: 0;
+    z-index: 1020;
+  }
+  .sticky-xl-bottom {
+    position: sticky;
+    bottom: 0;
+    z-index: 1020;
+  }
+}
+@media (min-width: 1400px) {
+  .sticky-xxl-top {
+    position: sticky;
+    top: 0;
+    z-index: 1020;
+  }
+  .sticky-xxl-bottom {
+    position: sticky;
+    bottom: 0;
+    z-index: 1020;
+  }
+}
+.hstack {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  align-self: stretch;
+}
+
+.vstack {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  align-self: stretch;
+}
+
+.visually-hidden,
+.visually-hidden-focusable:not(:focus):not(:focus-within) {
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+.visually-hidden:not(caption),
+.visually-hidden-focusable:not(:focus):not(:focus-within):not(caption) {
+  position: absolute !important;
+}
+.visually-hidden *,
+.visually-hidden-focusable:not(:focus):not(:focus-within) * {
+  overflow: hidden !important;
+}
+
+.stretched-link::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  content: "";
+}
+
+.text-truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vr {
+  display: inline-block;
+  align-self: stretch;
+  width: var(--bs-border-width);
+  min-height: 1em;
+  background-color: currentcolor;
+  opacity: 0.25;
+}
+
+.align-baseline {
+  vertical-align: baseline !important;
+}
+
+.align-top {
+  vertical-align: top !important;
+}
+
+.align-middle {
+  vertical-align: middle !important;
+}
+
+.align-bottom {
+  vertical-align: bottom !important;
+}
+
+.align-text-bottom {
+  vertical-align: text-bottom !important;
+}
+
+.align-text-top {
+  vertical-align: text-top !important;
+}
+
+.float-start {
+  float: left !important;
+}
+
+.float-end {
+  float: right !important;
+}
+
+.float-none {
+  float: none !important;
+}
+
+.object-fit-contain {
+  object-fit: contain !important;
+}
+
+.object-fit-cover {
+  object-fit: cover !important;
+}
+
+.object-fit-fill {
+  object-fit: fill !important;
+}
+
+.object-fit-scale {
+  object-fit: scale-down !important;
+}
+
+.object-fit-none {
+  object-fit: none !important;
+}
+
+.opacity-0 {
+  opacity: 0 !important;
+}
+
+.opacity-25 {
+  opacity: 0.25 !important;
+}
+
+.opacity-50 {
+  opacity: 0.5 !important;
+}
+
+.opacity-75 {
+  opacity: 0.75 !important;
+}
+
+.opacity-100 {
+  opacity: 1 !important;
+}
+
+.overflow-auto {
+  overflow: auto !important;
+}
+
+.overflow-hidden {
+  overflow: hidden !important;
+}
+
+.overflow-visible {
+  overflow: visible !important;
+}
+
+.overflow-scroll {
+  overflow: scroll !important;
+}
+
+.overflow-x-auto {
+  overflow-x: auto !important;
+}
+
+.overflow-x-hidden {
+  overflow-x: hidden !important;
+}
+
+.overflow-x-visible {
+  overflow-x: visible !important;
+}
+
+.overflow-x-scroll {
+  overflow-x: scroll !important;
+}
+
+.overflow-y-auto {
+  overflow-y: auto !important;
+}
+
+.overflow-y-hidden {
+  overflow-y: hidden !important;
+}
+
+.overflow-y-visible {
+  overflow-y: visible !important;
+}
+
+.overflow-y-scroll {
+  overflow-y: scroll !important;
+}
+
+.d-inline {
+  display: inline !important;
+}
+
+.d-inline-block {
+  display: inline-block !important;
+}
+
+.d-block {
+  display: block !important;
+}
+
+.d-grid {
+  display: grid !important;
+}
+
+.d-inline-grid {
+  display: inline-grid !important;
+}
+
+.d-table {
+  display: table !important;
+}
+
+.d-table-row {
+  display: table-row !important;
+}
+
+.d-table-cell {
+  display: table-cell !important;
+}
+
+.d-flex {
+  display: flex !important;
+}
+
+.d-inline-flex {
+  display: inline-flex !important;
+}
+
+.d-none {
+  display: none !important;
+}
+
+.shadow {
+  box-shadow: var(--bs-box-shadow) !important;
+}
+
+.shadow-sm {
+  box-shadow: var(--bs-box-shadow-sm) !important;
+}
+
+.shadow-lg {
+  box-shadow: var(--bs-box-shadow-lg) !important;
+}
+
+.shadow-none {
+  box-shadow: none !important;
+}
+
+.focus-ring-primary {
+  --bs-focus-ring-color: rgba(var(--bs-primary-rgb), var(--bs-focus-ring-opacity));
+}
+
+.focus-ring-secondary {
+  --bs-focus-ring-color: rgba(var(--bs-secondary-rgb), var(--bs-focus-ring-opacity));
+}
+
+.focus-ring-success {
+  --bs-focus-ring-color: rgba(var(--bs-success-rgb), var(--bs-focus-ring-opacity));
+}
+
+.focus-ring-info {
+  --bs-focus-ring-color: rgba(var(--bs-info-rgb), var(--bs-focus-ring-opacity));
+}
+
+.focus-ring-warning {
+  --bs-focus-ring-color: rgba(var(--bs-warning-rgb), var(--bs-focus-ring-opacity));
+}
+
+.focus-ring-danger {
+  --bs-focus-ring-color: rgba(var(--bs-danger-rgb), var(--bs-focus-ring-opacity));
+}
+
+.focus-ring-light {
+  --bs-focus-ring-color: rgba(var(--bs-light-rgb), var(--bs-focus-ring-opacity));
+}
+
+.focus-ring-dark {
+  --bs-focus-ring-color: rgba(var(--bs-dark-rgb), var(--bs-focus-ring-opacity));
+}
+
+.position-static {
+  position: static !important;
+}
+
+.position-relative {
+  position: relative !important;
+}
+
+.position-absolute {
+  position: absolute !important;
+}
+
+.position-fixed {
+  position: fixed !important;
+}
+
+.position-sticky {
+  position: sticky !important;
+}
+
+.top-0 {
+  top: 0 !important;
+}
+
+.top-50 {
+  top: 50% !important;
+}
+
+.top-100 {
+  top: 100% !important;
+}
+
+.bottom-0 {
+  bottom: 0 !important;
+}
+
+.bottom-50 {
+  bottom: 50% !important;
+}
+
+.bottom-100 {
+  bottom: 100% !important;
+}
+
+.start-0 {
+  left: 0 !important;
+}
+
+.start-50 {
+  left: 50% !important;
+}
+
+.start-100 {
+  left: 100% !important;
+}
+
+.end-0 {
+  right: 0 !important;
+}
+
+.end-50 {
+  right: 50% !important;
+}
+
+.end-100 {
+  right: 100% !important;
+}
+
+.translate-middle {
+  transform: translate(-50%, -50%) !important;
+}
+
+.translate-middle-x {
+  transform: translateX(-50%) !important;
+}
+
+.translate-middle-y {
+  transform: translateY(-50%) !important;
+}
+
+.border {
+  border: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color) !important;
+}
+
+.border-0 {
+  border: 0 !important;
+}
+
+.border-top {
+  border-top: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color) !important;
+}
+
+.border-top-0 {
+  border-top: 0 !important;
+}
+
+.border-end {
+  border-right: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color) !important;
+}
+
+.border-end-0 {
+  border-right: 0 !important;
+}
+
+.border-bottom {
+  border-bottom: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color) !important;
+}
+
+.border-bottom-0 {
+  border-bottom: 0 !important;
+}
+
+.border-start {
+  border-left: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color) !important;
+}
+
+.border-start-0 {
+  border-left: 0 !important;
+}
+
+.border-primary {
+  --bs-border-opacity: 1;
+  border-color: rgba(var(--bs-primary-rgb), var(--bs-border-opacity)) !important;
+}
+
+.border-secondary {
+  --bs-border-opacity: 1;
+  border-color: rgba(var(--bs-secondary-rgb), var(--bs-border-opacity)) !important;
+}
+
+.border-success {
+  --bs-border-opacity: 1;
+  border-color: rgba(var(--bs-success-rgb), var(--bs-border-opacity)) !important;
+}
+
+.border-info {
+  --bs-border-opacity: 1;
+  border-color: rgba(var(--bs-info-rgb), var(--bs-border-opacity)) !important;
+}
+
+.border-warning {
+  --bs-border-opacity: 1;
+  border-color: rgba(var(--bs-warning-rgb), var(--bs-border-opacity)) !important;
+}
+
+.border-danger {
+  --bs-border-opacity: 1;
+  border-color: rgba(var(--bs-danger-rgb), var(--bs-border-opacity)) !important;
+}
+
+.border-light {
+  --bs-border-opacity: 1;
+  border-color: rgba(var(--bs-light-rgb), var(--bs-border-opacity)) !important;
+}
+
+.border-dark {
+  --bs-border-opacity: 1;
+  border-color: rgba(var(--bs-dark-rgb), var(--bs-border-opacity)) !important;
+}
+
+.border-black {
+  --bs-border-opacity: 1;
+  border-color: rgba(var(--bs-black-rgb), var(--bs-border-opacity)) !important;
+}
+
+.border-white {
+  --bs-border-opacity: 1;
+  border-color: rgba(var(--bs-white-rgb), var(--bs-border-opacity)) !important;
+}
+
+.border-primary-subtle {
+  border-color: var(--bs-primary-border-subtle) !important;
+}
+
+.border-secondary-subtle {
+  border-color: var(--bs-secondary-border-subtle) !important;
+}
+
+.border-success-subtle {
+  border-color: var(--bs-success-border-subtle) !important;
+}
+
+.border-info-subtle {
+  border-color: var(--bs-info-border-subtle) !important;
+}
+
+.border-warning-subtle {
+  border-color: var(--bs-warning-border-subtle) !important;
+}
+
+.border-danger-subtle {
+  border-color: var(--bs-danger-border-subtle) !important;
+}
+
+.border-light-subtle {
+  border-color: var(--bs-light-border-subtle) !important;
+}
+
+.border-dark-subtle {
+  border-color: var(--bs-dark-border-subtle) !important;
+}
+
+.border-1 {
+  border-width: 1px !important;
+}
+
+.border-2 {
+  border-width: 2px !important;
+}
+
+.border-3 {
+  border-width: 3px !important;
+}
+
+.border-4 {
+  border-width: 4px !important;
+}
+
+.border-5 {
+  border-width: 5px !important;
+}
+
+.border-opacity-10 {
+  --bs-border-opacity: 0.1;
+}
+
+.border-opacity-25 {
+  --bs-border-opacity: 0.25;
+}
+
+.border-opacity-50 {
+  --bs-border-opacity: 0.5;
+}
+
+.border-opacity-75 {
+  --bs-border-opacity: 0.75;
+}
+
+.border-opacity-100 {
+  --bs-border-opacity: 1;
+}
+
+.w-25 {
+  width: 25% !important;
+}
+
+.w-50 {
+  width: 50% !important;
+}
+
+.w-75 {
+  width: 75% !important;
+}
+
+.w-100 {
+  width: 100% !important;
+}
+
+.w-auto {
+  width: auto !important;
+}
+
+.mw-100 {
+  max-width: 100% !important;
+}
+
+.vw-100 {
+  width: 100vw !important;
+}
+
+.min-vw-100 {
+  min-width: 100vw !important;
+}
+
+.h-25 {
+  height: 25% !important;
+}
+
+.h-50 {
+  height: 50% !important;
+}
+
+.h-75 {
+  height: 75% !important;
+}
+
+.h-100 {
+  height: 100% !important;
+}
+
+.h-auto {
+  height: auto !important;
+}
+
+.mh-100 {
+  max-height: 100% !important;
+}
+
+.vh-100 {
+  height: 100vh !important;
+}
+
+.min-vh-100 {
+  min-height: 100vh !important;
+}
+
+.flex-fill {
+  flex: 1 1 auto !important;
+}
+
+.flex-row {
+  flex-direction: row !important;
+}
+
+.flex-column {
+  flex-direction: column !important;
+}
+
+.flex-row-reverse {
+  flex-direction: row-reverse !important;
+}
+
+.flex-column-reverse {
+  flex-direction: column-reverse !important;
+}
+
+.flex-grow-0 {
+  flex-grow: 0 !important;
+}
+
+.flex-grow-1 {
+  flex-grow: 1 !important;
+}
+
+.flex-shrink-0 {
+  flex-shrink: 0 !important;
+}
+
+.flex-shrink-1 {
+  flex-shrink: 1 !important;
+}
+
+.flex-wrap {
+  flex-wrap: wrap !important;
+}
+
+.flex-nowrap {
+  flex-wrap: nowrap !important;
+}
+
+.flex-wrap-reverse {
+  flex-wrap: wrap-reverse !important;
+}
+
+.justify-content-start {
+  justify-content: flex-start !important;
+}
+
+.justify-content-end {
+  justify-content: flex-end !important;
+}
+
+.justify-content-center {
+  justify-content: center !important;
+}
+
+.justify-content-between {
+  justify-content: space-between !important;
+}
+
+.justify-content-around {
+  justify-content: space-around !important;
+}
+
+.justify-content-evenly {
+  justify-content: space-evenly !important;
+}
+
+.align-items-start {
+  align-items: flex-start !important;
+}
+
+.align-items-end {
+  align-items: flex-end !important;
+}
+
+.align-items-center {
+  align-items: center !important;
+}
+
+.align-items-baseline {
+  align-items: baseline !important;
+}
+
+.align-items-stretch {
+  align-items: stretch !important;
+}
+
+.align-content-start {
+  align-content: flex-start !important;
+}
+
+.align-content-end {
+  align-content: flex-end !important;
+}
+
+.align-content-center {
+  align-content: center !important;
+}
+
+.align-content-between {
+  align-content: space-between !important;
+}
+
+.align-content-around {
+  align-content: space-around !important;
+}
+
+.align-content-stretch {
+  align-content: stretch !important;
+}
+
+.align-self-auto {
+  align-self: auto !important;
+}
+
+.align-self-start {
+  align-self: flex-start !important;
+}
+
+.align-self-end {
+  align-self: flex-end !important;
+}
+
+.align-self-center {
+  align-self: center !important;
+}
+
+.align-self-baseline {
+  align-self: baseline !important;
+}
+
+.align-self-stretch {
+  align-self: stretch !important;
+}
+
+.order-first {
+  order: -1 !important;
+}
+
+.order-0 {
+  order: 0 !important;
+}
+
+.order-1 {
+  order: 1 !important;
+}
+
+.order-2 {
+  order: 2 !important;
+}
+
+.order-3 {
+  order: 3 !important;
+}
+
+.order-4 {
+  order: 4 !important;
+}
+
+.order-5 {
+  order: 5 !important;
+}
+
+.order-last {
+  order: 6 !important;
+}
+
+.m-0 {
+  margin: 0 !important;
+}
+
+.m-1 {
+  margin: 0.25rem !important;
+}
+
+.m-2 {
+  margin: 0.5rem !important;
+}
+
+.m-3 {
+  margin: 1rem !important;
+}
+
+.m-4 {
+  margin: 1.5rem !important;
+}
+
+.m-5 {
+  margin: 3rem !important;
+}
+
+.m-auto {
+  margin: auto !important;
+}
+
+.mx-0 {
+  margin-right: 0 !important;
+  margin-left: 0 !important;
+}
+
+.mx-1 {
+  margin-right: 0.25rem !important;
+  margin-left: 0.25rem !important;
+}
+
+.mx-2 {
+  margin-right: 0.5rem !important;
+  margin-left: 0.5rem !important;
+}
+
+.mx-3 {
+  margin-right: 1rem !important;
+  margin-left: 1rem !important;
+}
+
+.mx-4 {
+  margin-right: 1.5rem !important;
+  margin-left: 1.5rem !important;
+}
+
+.mx-5 {
+  margin-right: 3rem !important;
+  margin-left: 3rem !important;
+}
+
+.mx-auto {
+  margin-right: auto !important;
+  margin-left: auto !important;
+}
+
+.my-0 {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+.my-1 {
+  margin-top: 0.25rem !important;
+  margin-bottom: 0.25rem !important;
+}
+
+.my-2 {
+  margin-top: 0.5rem !important;
+  margin-bottom: 0.5rem !important;
+}
+
+.my-3 {
+  margin-top: 1rem !important;
+  margin-bottom: 1rem !important;
+}
+
+.my-4 {
+  margin-top: 1.5rem !important;
+  margin-bottom: 1.5rem !important;
+}
+
+.my-5 {
+  margin-top: 3rem !important;
+  margin-bottom: 3rem !important;
+}
+
+.my-auto {
+  margin-top: auto !important;
+  margin-bottom: auto !important;
+}
+
+.mt-0 {
+  margin-top: 0 !important;
+}
+
+.mt-1 {
+  margin-top: 0.25rem !important;
+}
+
+.mt-2 {
+  margin-top: 0.5rem !important;
+}
+
+.mt-3 {
+  margin-top: 1rem !important;
+}
+
+.mt-4 {
+  margin-top: 1.5rem !important;
+}
+
+.mt-5 {
+  margin-top: 3rem !important;
+}
+
+.mt-auto {
+  margin-top: auto !important;
+}
+
+.me-0 {
+  margin-right: 0 !important;
+}
+
+.me-1 {
+  margin-right: 0.25rem !important;
+}
+
+.me-2 {
+  margin-right: 0.5rem !important;
+}
+
+.me-3 {
+  margin-right: 1rem !important;
+}
+
+.me-4 {
+  margin-right: 1.5rem !important;
+}
+
+.me-5 {
+  margin-right: 3rem !important;
+}
+
+.me-auto {
+  margin-right: auto !important;
+}
+
+.mb-0 {
+  margin-bottom: 0 !important;
+}
+
+.mb-1 {
+  margin-bottom: 0.25rem !important;
+}
+
+.mb-2 {
+  margin-bottom: 0.5rem !important;
+}
+
+.mb-3 {
+  margin-bottom: 1rem !important;
+}
+
+.mb-4 {
+  margin-bottom: 1.5rem !important;
+}
+
+.mb-5 {
+  margin-bottom: 3rem !important;
+}
+
+.mb-auto {
+  margin-bottom: auto !important;
+}
+
+.ms-0 {
+  margin-left: 0 !important;
+}
+
+.ms-1 {
+  margin-left: 0.25rem !important;
+}
+
+.ms-2 {
+  margin-left: 0.5rem !important;
+}
+
+.ms-3 {
+  margin-left: 1rem !important;
+}
+
+.ms-4 {
+  margin-left: 1.5rem !important;
+}
+
+.ms-5 {
+  margin-left: 3rem !important;
+}
+
+.ms-auto {
+  margin-left: auto !important;
+}
+
+.p-0 {
+  padding: 0 !important;
+}
+
+.p-1 {
+  padding: 0.25rem !important;
+}
+
+.p-2 {
+  padding: 0.5rem !important;
+}
+
+.p-3 {
+  padding: 1rem !important;
+}
+
+.p-4 {
+  padding: 1.5rem !important;
+}
+
+.p-5 {
+  padding: 3rem !important;
+}
+
+.px-0 {
+  padding-right: 0 !important;
+  padding-left: 0 !important;
+}
+
+.px-1 {
+  padding-right: 0.25rem !important;
+  padding-left: 0.25rem !important;
+}
+
+.px-2 {
+  padding-right: 0.5rem !important;
+  padding-left: 0.5rem !important;
+}
+
+.px-3 {
+  padding-right: 1rem !important;
+  padding-left: 1rem !important;
+}
+
+.px-4 {
+  padding-right: 1.5rem !important;
+  padding-left: 1.5rem !important;
+}
+
+.px-5 {
+  padding-right: 3rem !important;
+  padding-left: 3rem !important;
+}
+
+.py-0 {
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+}
+
+.py-1 {
+  padding-top: 0.25rem !important;
+  padding-bottom: 0.25rem !important;
+}
+
+.py-2 {
+  padding-top: 0.5rem !important;
+  padding-bottom: 0.5rem !important;
+}
+
+.py-3 {
+  padding-top: 1rem !important;
+  padding-bottom: 1rem !important;
+}
+
+.py-4 {
+  padding-top: 1.5rem !important;
+  padding-bottom: 1.5rem !important;
+}
+
+.py-5 {
+  padding-top: 3rem !important;
+  padding-bottom: 3rem !important;
+}
+
+.pt-0 {
+  padding-top: 0 !important;
+}
+
+.pt-1 {
+  padding-top: 0.25rem !important;
+}
+
+.pt-2 {
+  padding-top: 0.5rem !important;
+}
+
+.pt-3 {
+  padding-top: 1rem !important;
+}
+
+.pt-4 {
+  padding-top: 1.5rem !important;
+}
+
+.pt-5 {
+  padding-top: 3rem !important;
+}
+
+.pe-0 {
+  padding-right: 0 !important;
+}
+
+.pe-1 {
+  padding-right: 0.25rem !important;
+}
+
+.pe-2 {
+  padding-right: 0.5rem !important;
+}
+
+.pe-3 {
+  padding-right: 1rem !important;
+}
+
+.pe-4 {
+  padding-right: 1.5rem !important;
+}
+
+.pe-5 {
+  padding-right: 3rem !important;
+}
+
+.pb-0 {
+  padding-bottom: 0 !important;
+}
+
+.pb-1 {
+  padding-bottom: 0.25rem !important;
+}
+
+.pb-2 {
+  padding-bottom: 0.5rem !important;
+}
+
+.pb-3 {
+  padding-bottom: 1rem !important;
+}
+
+.pb-4 {
+  padding-bottom: 1.5rem !important;
+}
+
+.pb-5 {
+  padding-bottom: 3rem !important;
+}
+
+.ps-0 {
+  padding-left: 0 !important;
+}
+
+.ps-1 {
+  padding-left: 0.25rem !important;
+}
+
+.ps-2 {
+  padding-left: 0.5rem !important;
+}
+
+.ps-3 {
+  padding-left: 1rem !important;
+}
+
+.ps-4 {
+  padding-left: 1.5rem !important;
+}
+
+.ps-5 {
+  padding-left: 3rem !important;
+}
+
+.gap-0 {
+  gap: 0 !important;
+}
+
+.gap-1 {
+  gap: 0.25rem !important;
+}
+
+.gap-2 {
+  gap: 0.5rem !important;
+}
+
+.gap-3 {
+  gap: 1rem !important;
+}
+
+.gap-4 {
+  gap: 1.5rem !important;
+}
+
+.gap-5 {
+  gap: 3rem !important;
+}
+
+.row-gap-0 {
+  row-gap: 0 !important;
+}
+
+.row-gap-1 {
+  row-gap: 0.25rem !important;
+}
+
+.row-gap-2 {
+  row-gap: 0.5rem !important;
+}
+
+.row-gap-3 {
+  row-gap: 1rem !important;
+}
+
+.row-gap-4 {
+  row-gap: 1.5rem !important;
+}
+
+.row-gap-5 {
+  row-gap: 3rem !important;
+}
+
+.column-gap-0 {
+  column-gap: 0 !important;
+}
+
+.column-gap-1 {
+  column-gap: 0.25rem !important;
+}
+
+.column-gap-2 {
+  column-gap: 0.5rem !important;
+}
+
+.column-gap-3 {
+  column-gap: 1rem !important;
+}
+
+.column-gap-4 {
+  column-gap: 1.5rem !important;
+}
+
+.column-gap-5 {
+  column-gap: 3rem !important;
+}
+
+.font-monospace {
+  font-family: var(--bs-font-monospace) !important;
+}
+
+.fs-1 {
+  font-size: calc(1.375rem + 1.5vw) !important;
+}
+
+.fs-2 {
+  font-size: calc(1.325rem + 0.9vw) !important;
+}
+
+.fs-3 {
+  font-size: calc(1.3rem + 0.6vw) !important;
+}
+
+.fs-4 {
+  font-size: calc(1.275rem + 0.3vw) !important;
+}
+
+.fs-5 {
+  font-size: 1.25rem !important;
+}
+
+.fs-6 {
+  font-size: 1rem !important;
+}
+
+.fst-italic {
+  font-style: italic !important;
+}
+
+.fst-normal {
+  font-style: normal !important;
+}
+
+.fw-lighter {
+  font-weight: lighter !important;
+}
+
+.fw-light {
+  font-weight: 300 !important;
+}
+
+.fw-normal {
+  font-weight: 400 !important;
+}
+
+.fw-medium {
+  font-weight: 500 !important;
+}
+
+.fw-semibold {
+  font-weight: 600 !important;
+}
+
+.fw-bold {
+  font-weight: 700 !important;
+}
+
+.fw-bolder {
+  font-weight: bolder !important;
+}
+
+.lh-1 {
+  line-height: 1 !important;
+}
+
+.lh-sm {
+  line-height: 1.25 !important;
+}
+
+.lh-base {
+  line-height: 1.5 !important;
+}
+
+.lh-lg {
+  line-height: 2 !important;
+}
+
+.text-start {
+  text-align: left !important;
+}
+
+.text-end {
+  text-align: right !important;
+}
+
+.text-center {
+  text-align: center !important;
+}
+
+.text-decoration-none {
+  text-decoration: none !important;
+}
+
+.text-decoration-underline {
+  text-decoration: underline !important;
+}
+
+.text-decoration-line-through {
+  text-decoration: line-through !important;
+}
+
+.text-lowercase {
+  text-transform: lowercase !important;
+}
+
+.text-uppercase {
+  text-transform: uppercase !important;
+}
+
+.text-capitalize {
+  text-transform: capitalize !important;
+}
+
+.text-wrap {
+  white-space: normal !important;
+}
+
+.text-nowrap {
+  white-space: nowrap !important;
+}
+
+/* rtl:begin:remove */
+.text-break {
+  word-wrap: break-word !important;
+  word-break: break-word !important;
+}
+
+/* rtl:end:remove */
+.text-primary {
+  --bs-text-opacity: 1;
+  color: rgba(var(--bs-primary-rgb), var(--bs-text-opacity)) !important;
+}
+
+.text-secondary {
+  --bs-text-opacity: 1;
+  color: rgba(var(--bs-secondary-rgb), var(--bs-text-opacity)) !important;
+}
+
+.text-success {
+  --bs-text-opacity: 1;
+  color: rgba(var(--bs-success-rgb), var(--bs-text-opacity)) !important;
+}
+
+.text-info {
+  --bs-text-opacity: 1;
+  color: rgba(var(--bs-info-rgb), var(--bs-text-opacity)) !important;
+}
+
+.text-warning {
+  --bs-text-opacity: 1;
+  color: rgba(var(--bs-warning-rgb), var(--bs-text-opacity)) !important;
+}
+
+.text-danger {
+  --bs-text-opacity: 1;
+  color: rgba(var(--bs-danger-rgb), var(--bs-text-opacity)) !important;
+}
+
+.text-light {
+  --bs-text-opacity: 1;
+  color: rgba(var(--bs-light-rgb), var(--bs-text-opacity)) !important;
+}
+
+.text-dark {
+  --bs-text-opacity: 1;
+  color: rgba(var(--bs-dark-rgb), var(--bs-text-opacity)) !important;
+}
+
+.text-black {
+  --bs-text-opacity: 1;
+  color: rgba(var(--bs-black-rgb), var(--bs-text-opacity)) !important;
+}
+
+.text-white {
+  --bs-text-opacity: 1;
+  color: rgba(var(--bs-white-rgb), var(--bs-text-opacity)) !important;
+}
+
+.text-body {
+  --bs-text-opacity: 1;
+  color: rgba(var(--bs-body-color-rgb), var(--bs-text-opacity)) !important;
+}
+
+.text-muted {
+  --bs-text-opacity: 1;
+  color: var(--bs-secondary-color) !important;
+}
+
+.text-black-50 {
+  --bs-text-opacity: 1;
+  color: rgba(0, 0, 0, 0.5) !important;
+}
+
+.text-white-50 {
+  --bs-text-opacity: 1;
+  color: rgba(255, 255, 255, 0.5) !important;
+}
+
+.text-body-secondary {
+  --bs-text-opacity: 1;
+  color: var(--bs-secondary-color) !important;
+}
+
+.text-body-tertiary {
+  --bs-text-opacity: 1;
+  color: var(--bs-tertiary-color) !important;
+}
+
+.text-body-emphasis {
+  --bs-text-opacity: 1;
+  color: var(--bs-emphasis-color) !important;
+}
+
+.text-reset {
+  --bs-text-opacity: 1;
+  color: inherit !important;
+}
+
+.text-opacity-25 {
+  --bs-text-opacity: 0.25;
+}
+
+.text-opacity-50 {
+  --bs-text-opacity: 0.5;
+}
+
+.text-opacity-75 {
+  --bs-text-opacity: 0.75;
+}
+
+.text-opacity-100 {
+  --bs-text-opacity: 1;
+}
+
+.text-primary-emphasis {
+  color: var(--bs-primary-text-emphasis) !important;
+}
+
+.text-secondary-emphasis {
+  color: var(--bs-secondary-text-emphasis) !important;
+}
+
+.text-success-emphasis {
+  color: var(--bs-success-text-emphasis) !important;
+}
+
+.text-info-emphasis {
+  color: var(--bs-info-text-emphasis) !important;
+}
+
+.text-warning-emphasis {
+  color: var(--bs-warning-text-emphasis) !important;
+}
+
+.text-danger-emphasis {
+  color: var(--bs-danger-text-emphasis) !important;
+}
+
+.text-light-emphasis {
+  color: var(--bs-light-text-emphasis) !important;
+}
+
+.text-dark-emphasis {
+  color: var(--bs-dark-text-emphasis) !important;
+}
+
+.link-opacity-10 {
+  --bs-link-opacity: 0.1;
+}
+
+.link-opacity-10-hover:hover {
+  --bs-link-opacity: 0.1;
+}
+
+.link-opacity-25 {
+  --bs-link-opacity: 0.25;
+}
+
+.link-opacity-25-hover:hover {
+  --bs-link-opacity: 0.25;
+}
+
+.link-opacity-50 {
+  --bs-link-opacity: 0.5;
+}
+
+.link-opacity-50-hover:hover {
+  --bs-link-opacity: 0.5;
+}
+
+.link-opacity-75 {
+  --bs-link-opacity: 0.75;
+}
+
+.link-opacity-75-hover:hover {
+  --bs-link-opacity: 0.75;
+}
+
+.link-opacity-100 {
+  --bs-link-opacity: 1;
+}
+
+.link-opacity-100-hover:hover {
+  --bs-link-opacity: 1;
+}
+
+.link-offset-1 {
+  text-underline-offset: 0.125em !important;
+}
+
+.link-offset-1-hover:hover {
+  text-underline-offset: 0.125em !important;
+}
+
+.link-offset-2 {
+  text-underline-offset: 0.25em !important;
+}
+
+.link-offset-2-hover:hover {
+  text-underline-offset: 0.25em !important;
+}
+
+.link-offset-3 {
+  text-underline-offset: 0.375em !important;
+}
+
+.link-offset-3-hover:hover {
+  text-underline-offset: 0.375em !important;
+}
+
+.link-underline-primary {
+  --bs-link-underline-opacity: 1;
+  text-decoration-color: rgba(var(--bs-primary-rgb), var(--bs-link-underline-opacity)) !important;
+}
+
+.link-underline-secondary {
+  --bs-link-underline-opacity: 1;
+  text-decoration-color: rgba(var(--bs-secondary-rgb), var(--bs-link-underline-opacity)) !important;
+}
+
+.link-underline-success {
+  --bs-link-underline-opacity: 1;
+  text-decoration-color: rgba(var(--bs-success-rgb), var(--bs-link-underline-opacity)) !important;
+}
+
+.link-underline-info {
+  --bs-link-underline-opacity: 1;
+  text-decoration-color: rgba(var(--bs-info-rgb), var(--bs-link-underline-opacity)) !important;
+}
+
+.link-underline-warning {
+  --bs-link-underline-opacity: 1;
+  text-decoration-color: rgba(var(--bs-warning-rgb), var(--bs-link-underline-opacity)) !important;
+}
+
+.link-underline-danger {
+  --bs-link-underline-opacity: 1;
+  text-decoration-color: rgba(var(--bs-danger-rgb), var(--bs-link-underline-opacity)) !important;
+}
+
+.link-underline-light {
+  --bs-link-underline-opacity: 1;
+  text-decoration-color: rgba(var(--bs-light-rgb), var(--bs-link-underline-opacity)) !important;
+}
+
+.link-underline-dark {
+  --bs-link-underline-opacity: 1;
+  text-decoration-color: rgba(var(--bs-dark-rgb), var(--bs-link-underline-opacity)) !important;
+}
+
+.link-underline {
+  --bs-link-underline-opacity: 1;
+  text-decoration-color: rgba(var(--bs-link-color-rgb), var(--bs-link-underline-opacity, 1)) !important;
+}
+
+.link-underline-opacity-0 {
+  --bs-link-underline-opacity: 0;
+}
+
+.link-underline-opacity-0-hover:hover {
+  --bs-link-underline-opacity: 0;
+}
+
+.link-underline-opacity-10 {
+  --bs-link-underline-opacity: 0.1;
+}
+
+.link-underline-opacity-10-hover:hover {
+  --bs-link-underline-opacity: 0.1;
+}
+
+.link-underline-opacity-25 {
+  --bs-link-underline-opacity: 0.25;
+}
+
+.link-underline-opacity-25-hover:hover {
+  --bs-link-underline-opacity: 0.25;
+}
+
+.link-underline-opacity-50 {
+  --bs-link-underline-opacity: 0.5;
+}
+
+.link-underline-opacity-50-hover:hover {
+  --bs-link-underline-opacity: 0.5;
+}
+
+.link-underline-opacity-75 {
+  --bs-link-underline-opacity: 0.75;
+}
+
+.link-underline-opacity-75-hover:hover {
+  --bs-link-underline-opacity: 0.75;
+}
+
+.link-underline-opacity-100 {
+  --bs-link-underline-opacity: 1;
+}
+
+.link-underline-opacity-100-hover:hover {
+  --bs-link-underline-opacity: 1;
+}
+
+.bg-primary {
+  --bs-bg-opacity: 1;
+  background-color: rgba(var(--bs-primary-rgb), var(--bs-bg-opacity)) !important;
+}
+
+.bg-secondary {
+  --bs-bg-opacity: 1;
+  background-color: rgba(var(--bs-secondary-rgb), var(--bs-bg-opacity)) !important;
+}
+
+.bg-success {
+  --bs-bg-opacity: 1;
+  background-color: rgba(var(--bs-success-rgb), var(--bs-bg-opacity)) !important;
+}
+
+.bg-info {
+  --bs-bg-opacity: 1;
+  background-color: rgba(var(--bs-info-rgb), var(--bs-bg-opacity)) !important;
+}
+
+.bg-warning {
+  --bs-bg-opacity: 1;
+  background-color: rgba(var(--bs-warning-rgb), var(--bs-bg-opacity)) !important;
+}
+
+.bg-danger {
+  --bs-bg-opacity: 1;
+  background-color: rgba(var(--bs-danger-rgb), var(--bs-bg-opacity)) !important;
+}
+
+.bg-light {
+  --bs-bg-opacity: 1;
+  background-color: rgba(var(--bs-light-rgb), var(--bs-bg-opacity)) !important;
+}
+
+.bg-dark {
+  --bs-bg-opacity: 1;
+  background-color: rgba(var(--bs-dark-rgb), var(--bs-bg-opacity)) !important;
+}
+
+.bg-black {
+  --bs-bg-opacity: 1;
+  background-color: rgba(var(--bs-black-rgb), var(--bs-bg-opacity)) !important;
+}
+
+.bg-white {
+  --bs-bg-opacity: 1;
+  background-color: rgba(var(--bs-white-rgb), var(--bs-bg-opacity)) !important;
+}
+
+.bg-body {
+  --bs-bg-opacity: 1;
+  background-color: rgba(var(--bs-body-bg-rgb), var(--bs-bg-opacity)) !important;
+}
+
+.bg-transparent {
+  --bs-bg-opacity: 1;
+  background-color: transparent !important;
+}
+
+.bg-body-secondary {
+  --bs-bg-opacity: 1;
+  background-color: rgba(var(--bs-secondary-bg-rgb), var(--bs-bg-opacity)) !important;
+}
+
+.bg-body-tertiary {
+  --bs-bg-opacity: 1;
+  background-color: rgba(var(--bs-tertiary-bg-rgb), var(--bs-bg-opacity)) !important;
+}
+
+.bg-opacity-10 {
+  --bs-bg-opacity: 0.1;
+}
+
+.bg-opacity-25 {
+  --bs-bg-opacity: 0.25;
+}
+
+.bg-opacity-50 {
+  --bs-bg-opacity: 0.5;
+}
+
+.bg-opacity-75 {
+  --bs-bg-opacity: 0.75;
+}
+
+.bg-opacity-100 {
+  --bs-bg-opacity: 1;
+}
+
+.bg-primary-subtle {
+  background-color: var(--bs-primary-bg-subtle) !important;
+}
+
+.bg-secondary-subtle {
+  background-color: var(--bs-secondary-bg-subtle) !important;
+}
+
+.bg-success-subtle {
+  background-color: var(--bs-success-bg-subtle) !important;
+}
+
+.bg-info-subtle {
+  background-color: var(--bs-info-bg-subtle) !important;
+}
+
+.bg-warning-subtle {
+  background-color: var(--bs-warning-bg-subtle) !important;
+}
+
+.bg-danger-subtle {
+  background-color: var(--bs-danger-bg-subtle) !important;
+}
+
+.bg-light-subtle {
+  background-color: var(--bs-light-bg-subtle) !important;
+}
+
+.bg-dark-subtle {
+  background-color: var(--bs-dark-bg-subtle) !important;
+}
+
+.bg-gradient {
+  background-image: var(--bs-gradient) !important;
+}
+
+.user-select-all {
+  user-select: all !important;
+}
+
+.user-select-auto {
+  user-select: auto !important;
+}
+
+.user-select-none {
+  user-select: none !important;
+}
+
+.pe-none {
+  pointer-events: none !important;
+}
+
+.pe-auto {
+  pointer-events: auto !important;
+}
+
+.rounded {
+  border-radius: var(--bs-border-radius) !important;
+}
+
+.rounded-0 {
+  border-radius: 0 !important;
+}
+
+.rounded-1 {
+  border-radius: var(--bs-border-radius-sm) !important;
+}
+
+.rounded-2 {
+  border-radius: var(--bs-border-radius) !important;
+}
+
+.rounded-3 {
+  border-radius: var(--bs-border-radius-lg) !important;
+}
+
+.rounded-4 {
+  border-radius: var(--bs-border-radius-xl) !important;
+}
+
+.rounded-5 {
+  border-radius: var(--bs-border-radius-xxl) !important;
+}
+
+.rounded-circle {
+  border-radius: 50% !important;
+}
+
+.rounded-pill {
+  border-radius: var(--bs-border-radius-pill) !important;
+}
+
+.rounded-top {
+  border-top-left-radius: var(--bs-border-radius) !important;
+  border-top-right-radius: var(--bs-border-radius) !important;
+}
+
+.rounded-top-0 {
+  border-top-left-radius: 0 !important;
+  border-top-right-radius: 0 !important;
+}
+
+.rounded-top-1 {
+  border-top-left-radius: var(--bs-border-radius-sm) !important;
+  border-top-right-radius: var(--bs-border-radius-sm) !important;
+}
+
+.rounded-top-2 {
+  border-top-left-radius: var(--bs-border-radius) !important;
+  border-top-right-radius: var(--bs-border-radius) !important;
+}
+
+.rounded-top-3 {
+  border-top-left-radius: var(--bs-border-radius-lg) !important;
+  border-top-right-radius: var(--bs-border-radius-lg) !important;
+}
+
+.rounded-top-4 {
+  border-top-left-radius: var(--bs-border-radius-xl) !important;
+  border-top-right-radius: var(--bs-border-radius-xl) !important;
+}
+
+.rounded-top-5 {
+  border-top-left-radius: var(--bs-border-radius-xxl) !important;
+  border-top-right-radius: var(--bs-border-radius-xxl) !important;
+}
+
+.rounded-top-circle {
+  border-top-left-radius: 50% !important;
+  border-top-right-radius: 50% !important;
+}
+
+.rounded-top-pill {
+  border-top-left-radius: var(--bs-border-radius-pill) !important;
+  border-top-right-radius: var(--bs-border-radius-pill) !important;
+}
+
+.rounded-end {
+  border-top-right-radius: var(--bs-border-radius) !important;
+  border-bottom-right-radius: var(--bs-border-radius) !important;
+}
+
+.rounded-end-0 {
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.rounded-end-1 {
+  border-top-right-radius: var(--bs-border-radius-sm) !important;
+  border-bottom-right-radius: var(--bs-border-radius-sm) !important;
+}
+
+.rounded-end-2 {
+  border-top-right-radius: var(--bs-border-radius) !important;
+  border-bottom-right-radius: var(--bs-border-radius) !important;
+}
+
+.rounded-end-3 {
+  border-top-right-radius: var(--bs-border-radius-lg) !important;
+  border-bottom-right-radius: var(--bs-border-radius-lg) !important;
+}
+
+.rounded-end-4 {
+  border-top-right-radius: var(--bs-border-radius-xl) !important;
+  border-bottom-right-radius: var(--bs-border-radius-xl) !important;
+}
+
+.rounded-end-5 {
+  border-top-right-radius: var(--bs-border-radius-xxl) !important;
+  border-bottom-right-radius: var(--bs-border-radius-xxl) !important;
+}
+
+.rounded-end-circle {
+  border-top-right-radius: 50% !important;
+  border-bottom-right-radius: 50% !important;
+}
+
+.rounded-end-pill {
+  border-top-right-radius: var(--bs-border-radius-pill) !important;
+  border-bottom-right-radius: var(--bs-border-radius-pill) !important;
+}
+
+.rounded-bottom {
+  border-bottom-right-radius: var(--bs-border-radius) !important;
+  border-bottom-left-radius: var(--bs-border-radius) !important;
+}
+
+.rounded-bottom-0 {
+  border-bottom-right-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+}
+
+.rounded-bottom-1 {
+  border-bottom-right-radius: var(--bs-border-radius-sm) !important;
+  border-bottom-left-radius: var(--bs-border-radius-sm) !important;
+}
+
+.rounded-bottom-2 {
+  border-bottom-right-radius: var(--bs-border-radius) !important;
+  border-bottom-left-radius: var(--bs-border-radius) !important;
+}
+
+.rounded-bottom-3 {
+  border-bottom-right-radius: var(--bs-border-radius-lg) !important;
+  border-bottom-left-radius: var(--bs-border-radius-lg) !important;
+}
+
+.rounded-bottom-4 {
+  border-bottom-right-radius: var(--bs-border-radius-xl) !important;
+  border-bottom-left-radius: var(--bs-border-radius-xl) !important;
+}
+
+.rounded-bottom-5 {
+  border-bottom-right-radius: var(--bs-border-radius-xxl) !important;
+  border-bottom-left-radius: var(--bs-border-radius-xxl) !important;
+}
+
+.rounded-bottom-circle {
+  border-bottom-right-radius: 50% !important;
+  border-bottom-left-radius: 50% !important;
+}
+
+.rounded-bottom-pill {
+  border-bottom-right-radius: var(--bs-border-radius-pill) !important;
+  border-bottom-left-radius: var(--bs-border-radius-pill) !important;
+}
+
+.rounded-start {
+  border-bottom-left-radius: var(--bs-border-radius) !important;
+  border-top-left-radius: var(--bs-border-radius) !important;
+}
+
+.rounded-start-0 {
+  border-bottom-left-radius: 0 !important;
+  border-top-left-radius: 0 !important;
+}
+
+.rounded-start-1 {
+  border-bottom-left-radius: var(--bs-border-radius-sm) !important;
+  border-top-left-radius: var(--bs-border-radius-sm) !important;
+}
+
+.rounded-start-2 {
+  border-bottom-left-radius: var(--bs-border-radius) !important;
+  border-top-left-radius: var(--bs-border-radius) !important;
+}
+
+.rounded-start-3 {
+  border-bottom-left-radius: var(--bs-border-radius-lg) !important;
+  border-top-left-radius: var(--bs-border-radius-lg) !important;
+}
+
+.rounded-start-4 {
+  border-bottom-left-radius: var(--bs-border-radius-xl) !important;
+  border-top-left-radius: var(--bs-border-radius-xl) !important;
+}
+
+.rounded-start-5 {
+  border-bottom-left-radius: var(--bs-border-radius-xxl) !important;
+  border-top-left-radius: var(--bs-border-radius-xxl) !important;
+}
+
+.rounded-start-circle {
+  border-bottom-left-radius: 50% !important;
+  border-top-left-radius: 50% !important;
+}
+
+.rounded-start-pill {
+  border-bottom-left-radius: var(--bs-border-radius-pill) !important;
+  border-top-left-radius: var(--bs-border-radius-pill) !important;
+}
+
+.visible {
+  visibility: visible !important;
+}
+
+.invisible {
+  visibility: hidden !important;
+}
+
+.z-n1 {
+  z-index: -1 !important;
+}
+
+.z-0 {
+  z-index: 0 !important;
+}
+
+.z-1 {
+  z-index: 1 !important;
+}
+
+.z-2 {
+  z-index: 2 !important;
+}
+
+.z-3 {
+  z-index: 3 !important;
+}
+
+@media (min-width: 576px) {
+  .float-sm-start {
+    float: left !important;
+  }
+  .float-sm-end {
+    float: right !important;
+  }
+  .float-sm-none {
+    float: none !important;
+  }
+  .object-fit-sm-contain {
+    object-fit: contain !important;
+  }
+  .object-fit-sm-cover {
+    object-fit: cover !important;
+  }
+  .object-fit-sm-fill {
+    object-fit: fill !important;
+  }
+  .object-fit-sm-scale {
+    object-fit: scale-down !important;
+  }
+  .object-fit-sm-none {
+    object-fit: none !important;
+  }
+  .d-sm-inline {
+    display: inline !important;
+  }
+  .d-sm-inline-block {
+    display: inline-block !important;
+  }
+  .d-sm-block {
+    display: block !important;
+  }
+  .d-sm-grid {
+    display: grid !important;
+  }
+  .d-sm-inline-grid {
+    display: inline-grid !important;
+  }
+  .d-sm-table {
+    display: table !important;
+  }
+  .d-sm-table-row {
+    display: table-row !important;
+  }
+  .d-sm-table-cell {
+    display: table-cell !important;
+  }
+  .d-sm-flex {
+    display: flex !important;
+  }
+  .d-sm-inline-flex {
+    display: inline-flex !important;
+  }
+  .d-sm-none {
+    display: none !important;
+  }
+  .flex-sm-fill {
+    flex: 1 1 auto !important;
+  }
+  .flex-sm-row {
+    flex-direction: row !important;
+  }
+  .flex-sm-column {
+    flex-direction: column !important;
+  }
+  .flex-sm-row-reverse {
+    flex-direction: row-reverse !important;
+  }
+  .flex-sm-column-reverse {
+    flex-direction: column-reverse !important;
+  }
+  .flex-sm-grow-0 {
+    flex-grow: 0 !important;
+  }
+  .flex-sm-grow-1 {
+    flex-grow: 1 !important;
+  }
+  .flex-sm-shrink-0 {
+    flex-shrink: 0 !important;
+  }
+  .flex-sm-shrink-1 {
+    flex-shrink: 1 !important;
+  }
+  .flex-sm-wrap {
+    flex-wrap: wrap !important;
+  }
+  .flex-sm-nowrap {
+    flex-wrap: nowrap !important;
+  }
+  .flex-sm-wrap-reverse {
+    flex-wrap: wrap-reverse !important;
+  }
+  .justify-content-sm-start {
+    justify-content: flex-start !important;
+  }
+  .justify-content-sm-end {
+    justify-content: flex-end !important;
+  }
+  .justify-content-sm-center {
+    justify-content: center !important;
+  }
+  .justify-content-sm-between {
+    justify-content: space-between !important;
+  }
+  .justify-content-sm-around {
+    justify-content: space-around !important;
+  }
+  .justify-content-sm-evenly {
+    justify-content: space-evenly !important;
+  }
+  .align-items-sm-start {
+    align-items: flex-start !important;
+  }
+  .align-items-sm-end {
+    align-items: flex-end !important;
+  }
+  .align-items-sm-center {
+    align-items: center !important;
+  }
+  .align-items-sm-baseline {
+    align-items: baseline !important;
+  }
+  .align-items-sm-stretch {
+    align-items: stretch !important;
+  }
+  .align-content-sm-start {
+    align-content: flex-start !important;
+  }
+  .align-content-sm-end {
+    align-content: flex-end !important;
+  }
+  .align-content-sm-center {
+    align-content: center !important;
+  }
+  .align-content-sm-between {
+    align-content: space-between !important;
+  }
+  .align-content-sm-around {
+    align-content: space-around !important;
+  }
+  .align-content-sm-stretch {
+    align-content: stretch !important;
+  }
+  .align-self-sm-auto {
+    align-self: auto !important;
+  }
+  .align-self-sm-start {
+    align-self: flex-start !important;
+  }
+  .align-self-sm-end {
+    align-self: flex-end !important;
+  }
+  .align-self-sm-center {
+    align-self: center !important;
+  }
+  .align-self-sm-baseline {
+    align-self: baseline !important;
+  }
+  .align-self-sm-stretch {
+    align-self: stretch !important;
+  }
+  .order-sm-first {
+    order: -1 !important;
+  }
+  .order-sm-0 {
+    order: 0 !important;
+  }
+  .order-sm-1 {
+    order: 1 !important;
+  }
+  .order-sm-2 {
+    order: 2 !important;
+  }
+  .order-sm-3 {
+    order: 3 !important;
+  }
+  .order-sm-4 {
+    order: 4 !important;
+  }
+  .order-sm-5 {
+    order: 5 !important;
+  }
+  .order-sm-last {
+    order: 6 !important;
+  }
+  .m-sm-0 {
+    margin: 0 !important;
+  }
+  .m-sm-1 {
+    margin: 0.25rem !important;
+  }
+  .m-sm-2 {
+    margin: 0.5rem !important;
+  }
+  .m-sm-3 {
+    margin: 1rem !important;
+  }
+  .m-sm-4 {
+    margin: 1.5rem !important;
+  }
+  .m-sm-5 {
+    margin: 3rem !important;
+  }
+  .m-sm-auto {
+    margin: auto !important;
+  }
+  .mx-sm-0 {
+    margin-right: 0 !important;
+    margin-left: 0 !important;
+  }
+  .mx-sm-1 {
+    margin-right: 0.25rem !important;
+    margin-left: 0.25rem !important;
+  }
+  .mx-sm-2 {
+    margin-right: 0.5rem !important;
+    margin-left: 0.5rem !important;
+  }
+  .mx-sm-3 {
+    margin-right: 1rem !important;
+    margin-left: 1rem !important;
+  }
+  .mx-sm-4 {
+    margin-right: 1.5rem !important;
+    margin-left: 1.5rem !important;
+  }
+  .mx-sm-5 {
+    margin-right: 3rem !important;
+    margin-left: 3rem !important;
+  }
+  .mx-sm-auto {
+    margin-right: auto !important;
+    margin-left: auto !important;
+  }
+  .my-sm-0 {
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+  }
+  .my-sm-1 {
+    margin-top: 0.25rem !important;
+    margin-bottom: 0.25rem !important;
+  }
+  .my-sm-2 {
+    margin-top: 0.5rem !important;
+    margin-bottom: 0.5rem !important;
+  }
+  .my-sm-3 {
+    margin-top: 1rem !important;
+    margin-bottom: 1rem !important;
+  }
+  .my-sm-4 {
+    margin-top: 1.5rem !important;
+    margin-bottom: 1.5rem !important;
+  }
+  .my-sm-5 {
+    margin-top: 3rem !important;
+    margin-bottom: 3rem !important;
+  }
+  .my-sm-auto {
+    margin-top: auto !important;
+    margin-bottom: auto !important;
+  }
+  .mt-sm-0 {
+    margin-top: 0 !important;
+  }
+  .mt-sm-1 {
+    margin-top: 0.25rem !important;
+  }
+  .mt-sm-2 {
+    margin-top: 0.5rem !important;
+  }
+  .mt-sm-3 {
+    margin-top: 1rem !important;
+  }
+  .mt-sm-4 {
+    margin-top: 1.5rem !important;
+  }
+  .mt-sm-5 {
+    margin-top: 3rem !important;
+  }
+  .mt-sm-auto {
+    margin-top: auto !important;
+  }
+  .me-sm-0 {
+    margin-right: 0 !important;
+  }
+  .me-sm-1 {
+    margin-right: 0.25rem !important;
+  }
+  .me-sm-2 {
+    margin-right: 0.5rem !important;
+  }
+  .me-sm-3 {
+    margin-right: 1rem !important;
+  }
+  .me-sm-4 {
+    margin-right: 1.5rem !important;
+  }
+  .me-sm-5 {
+    margin-right: 3rem !important;
+  }
+  .me-sm-auto {
+    margin-right: auto !important;
+  }
+  .mb-sm-0 {
+    margin-bottom: 0 !important;
+  }
+  .mb-sm-1 {
+    margin-bottom: 0.25rem !important;
+  }
+  .mb-sm-2 {
+    margin-bottom: 0.5rem !important;
+  }
+  .mb-sm-3 {
+    margin-bottom: 1rem !important;
+  }
+  .mb-sm-4 {
+    margin-bottom: 1.5rem !important;
+  }
+  .mb-sm-5 {
+    margin-bottom: 3rem !important;
+  }
+  .mb-sm-auto {
+    margin-bottom: auto !important;
+  }
+  .ms-sm-0 {
+    margin-left: 0 !important;
+  }
+  .ms-sm-1 {
+    margin-left: 0.25rem !important;
+  }
+  .ms-sm-2 {
+    margin-left: 0.5rem !important;
+  }
+  .ms-sm-3 {
+    margin-left: 1rem !important;
+  }
+  .ms-sm-4 {
+    margin-left: 1.5rem !important;
+  }
+  .ms-sm-5 {
+    margin-left: 3rem !important;
+  }
+  .ms-sm-auto {
+    margin-left: auto !important;
+  }
+  .p-sm-0 {
+    padding: 0 !important;
+  }
+  .p-sm-1 {
+    padding: 0.25rem !important;
+  }
+  .p-sm-2 {
+    padding: 0.5rem !important;
+  }
+  .p-sm-3 {
+    padding: 1rem !important;
+  }
+  .p-sm-4 {
+    padding: 1.5rem !important;
+  }
+  .p-sm-5 {
+    padding: 3rem !important;
+  }
+  .px-sm-0 {
+    padding-right: 0 !important;
+    padding-left: 0 !important;
+  }
+  .px-sm-1 {
+    padding-right: 0.25rem !important;
+    padding-left: 0.25rem !important;
+  }
+  .px-sm-2 {
+    padding-right: 0.5rem !important;
+    padding-left: 0.5rem !important;
+  }
+  .px-sm-3 {
+    padding-right: 1rem !important;
+    padding-left: 1rem !important;
+  }
+  .px-sm-4 {
+    padding-right: 1.5rem !important;
+    padding-left: 1.5rem !important;
+  }
+  .px-sm-5 {
+    padding-right: 3rem !important;
+    padding-left: 3rem !important;
+  }
+  .py-sm-0 {
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+  }
+  .py-sm-1 {
+    padding-top: 0.25rem !important;
+    padding-bottom: 0.25rem !important;
+  }
+  .py-sm-2 {
+    padding-top: 0.5rem !important;
+    padding-bottom: 0.5rem !important;
+  }
+  .py-sm-3 {
+    padding-top: 1rem !important;
+    padding-bottom: 1rem !important;
+  }
+  .py-sm-4 {
+    padding-top: 1.5rem !important;
+    padding-bottom: 1.5rem !important;
+  }
+  .py-sm-5 {
+    padding-top: 3rem !important;
+    padding-bottom: 3rem !important;
+  }
+  .pt-sm-0 {
+    padding-top: 0 !important;
+  }
+  .pt-sm-1 {
+    padding-top: 0.25rem !important;
+  }
+  .pt-sm-2 {
+    padding-top: 0.5rem !important;
+  }
+  .pt-sm-3 {
+    padding-top: 1rem !important;
+  }
+  .pt-sm-4 {
+    padding-top: 1.5rem !important;
+  }
+  .pt-sm-5 {
+    padding-top: 3rem !important;
+  }
+  .pe-sm-0 {
+    padding-right: 0 !important;
+  }
+  .pe-sm-1 {
+    padding-right: 0.25rem !important;
+  }
+  .pe-sm-2 {
+    padding-right: 0.5rem !important;
+  }
+  .pe-sm-3 {
+    padding-right: 1rem !important;
+  }
+  .pe-sm-4 {
+    padding-right: 1.5rem !important;
+  }
+  .pe-sm-5 {
+    padding-right: 3rem !important;
+  }
+  .pb-sm-0 {
+    padding-bottom: 0 !important;
+  }
+  .pb-sm-1 {
+    padding-bottom: 0.25rem !important;
+  }
+  .pb-sm-2 {
+    padding-bottom: 0.5rem !important;
+  }
+  .pb-sm-3 {
+    padding-bottom: 1rem !important;
+  }
+  .pb-sm-4 {
+    padding-bottom: 1.5rem !important;
+  }
+  .pb-sm-5 {
+    padding-bottom: 3rem !important;
+  }
+  .ps-sm-0 {
+    padding-left: 0 !important;
+  }
+  .ps-sm-1 {
+    padding-left: 0.25rem !important;
+  }
+  .ps-sm-2 {
+    padding-left: 0.5rem !important;
+  }
+  .ps-sm-3 {
+    padding-left: 1rem !important;
+  }
+  .ps-sm-4 {
+    padding-left: 1.5rem !important;
+  }
+  .ps-sm-5 {
+    padding-left: 3rem !important;
+  }
+  .gap-sm-0 {
+    gap: 0 !important;
+  }
+  .gap-sm-1 {
+    gap: 0.25rem !important;
+  }
+  .gap-sm-2 {
+    gap: 0.5rem !important;
+  }
+  .gap-sm-3 {
+    gap: 1rem !important;
+  }
+  .gap-sm-4 {
+    gap: 1.5rem !important;
+  }
+  .gap-sm-5 {
+    gap: 3rem !important;
+  }
+  .row-gap-sm-0 {
+    row-gap: 0 !important;
+  }
+  .row-gap-sm-1 {
+    row-gap: 0.25rem !important;
+  }
+  .row-gap-sm-2 {
+    row-gap: 0.5rem !important;
+  }
+  .row-gap-sm-3 {
+    row-gap: 1rem !important;
+  }
+  .row-gap-sm-4 {
+    row-gap: 1.5rem !important;
+  }
+  .row-gap-sm-5 {
+    row-gap: 3rem !important;
+  }
+  .column-gap-sm-0 {
+    column-gap: 0 !important;
+  }
+  .column-gap-sm-1 {
+    column-gap: 0.25rem !important;
+  }
+  .column-gap-sm-2 {
+    column-gap: 0.5rem !important;
+  }
+  .column-gap-sm-3 {
+    column-gap: 1rem !important;
+  }
+  .column-gap-sm-4 {
+    column-gap: 1.5rem !important;
+  }
+  .column-gap-sm-5 {
+    column-gap: 3rem !important;
+  }
+  .text-sm-start {
+    text-align: left !important;
+  }
+  .text-sm-end {
+    text-align: right !important;
+  }
+  .text-sm-center {
+    text-align: center !important;
+  }
+}
+@media (min-width: 768px) {
+  .float-md-start {
+    float: left !important;
+  }
+  .float-md-end {
+    float: right !important;
+  }
+  .float-md-none {
+    float: none !important;
+  }
+  .object-fit-md-contain {
+    object-fit: contain !important;
+  }
+  .object-fit-md-cover {
+    object-fit: cover !important;
+  }
+  .object-fit-md-fill {
+    object-fit: fill !important;
+  }
+  .object-fit-md-scale {
+    object-fit: scale-down !important;
+  }
+  .object-fit-md-none {
+    object-fit: none !important;
+  }
+  .d-md-inline {
+    display: inline !important;
+  }
+  .d-md-inline-block {
+    display: inline-block !important;
+  }
+  .d-md-block {
+    display: block !important;
+  }
+  .d-md-grid {
+    display: grid !important;
+  }
+  .d-md-inline-grid {
+    display: inline-grid !important;
+  }
+  .d-md-table {
+    display: table !important;
+  }
+  .d-md-table-row {
+    display: table-row !important;
+  }
+  .d-md-table-cell {
+    display: table-cell !important;
+  }
+  .d-md-flex {
+    display: flex !important;
+  }
+  .d-md-inline-flex {
+    display: inline-flex !important;
+  }
+  .d-md-none {
+    display: none !important;
+  }
+  .flex-md-fill {
+    flex: 1 1 auto !important;
+  }
+  .flex-md-row {
+    flex-direction: row !important;
+  }
+  .flex-md-column {
+    flex-direction: column !important;
+  }
+  .flex-md-row-reverse {
+    flex-direction: row-reverse !important;
+  }
+  .flex-md-column-reverse {
+    flex-direction: column-reverse !important;
+  }
+  .flex-md-grow-0 {
+    flex-grow: 0 !important;
+  }
+  .flex-md-grow-1 {
+    flex-grow: 1 !important;
+  }
+  .flex-md-shrink-0 {
+    flex-shrink: 0 !important;
+  }
+  .flex-md-shrink-1 {
+    flex-shrink: 1 !important;
+  }
+  .flex-md-wrap {
+    flex-wrap: wrap !important;
+  }
+  .flex-md-nowrap {
+    flex-wrap: nowrap !important;
+  }
+  .flex-md-wrap-reverse {
+    flex-wrap: wrap-reverse !important;
+  }
+  .justify-content-md-start {
+    justify-content: flex-start !important;
+  }
+  .justify-content-md-end {
+    justify-content: flex-end !important;
+  }
+  .justify-content-md-center {
+    justify-content: center !important;
+  }
+  .justify-content-md-between {
+    justify-content: space-between !important;
+  }
+  .justify-content-md-around {
+    justify-content: space-around !important;
+  }
+  .justify-content-md-evenly {
+    justify-content: space-evenly !important;
+  }
+  .align-items-md-start {
+    align-items: flex-start !important;
+  }
+  .align-items-md-end {
+    align-items: flex-end !important;
+  }
+  .align-items-md-center {
+    align-items: center !important;
+  }
+  .align-items-md-baseline {
+    align-items: baseline !important;
+  }
+  .align-items-md-stretch {
+    align-items: stretch !important;
+  }
+  .align-content-md-start {
+    align-content: flex-start !important;
+  }
+  .align-content-md-end {
+    align-content: flex-end !important;
+  }
+  .align-content-md-center {
+    align-content: center !important;
+  }
+  .align-content-md-between {
+    align-content: space-between !important;
+  }
+  .align-content-md-around {
+    align-content: space-around !important;
+  }
+  .align-content-md-stretch {
+    align-content: stretch !important;
+  }
+  .align-self-md-auto {
+    align-self: auto !important;
+  }
+  .align-self-md-start {
+    align-self: flex-start !important;
+  }
+  .align-self-md-end {
+    align-self: flex-end !important;
+  }
+  .align-self-md-center {
+    align-self: center !important;
+  }
+  .align-self-md-baseline {
+    align-self: baseline !important;
+  }
+  .align-self-md-stretch {
+    align-self: stretch !important;
+  }
+  .order-md-first {
+    order: -1 !important;
+  }
+  .order-md-0 {
+    order: 0 !important;
+  }
+  .order-md-1 {
+    order: 1 !important;
+  }
+  .order-md-2 {
+    order: 2 !important;
+  }
+  .order-md-3 {
+    order: 3 !important;
+  }
+  .order-md-4 {
+    order: 4 !important;
+  }
+  .order-md-5 {
+    order: 5 !important;
+  }
+  .order-md-last {
+    order: 6 !important;
+  }
+  .m-md-0 {
+    margin: 0 !important;
+  }
+  .m-md-1 {
+    margin: 0.25rem !important;
+  }
+  .m-md-2 {
+    margin: 0.5rem !important;
+  }
+  .m-md-3 {
+    margin: 1rem !important;
+  }
+  .m-md-4 {
+    margin: 1.5rem !important;
+  }
+  .m-md-5 {
+    margin: 3rem !important;
+  }
+  .m-md-auto {
+    margin: auto !important;
+  }
+  .mx-md-0 {
+    margin-right: 0 !important;
+    margin-left: 0 !important;
+  }
+  .mx-md-1 {
+    margin-right: 0.25rem !important;
+    margin-left: 0.25rem !important;
+  }
+  .mx-md-2 {
+    margin-right: 0.5rem !important;
+    margin-left: 0.5rem !important;
+  }
+  .mx-md-3 {
+    margin-right: 1rem !important;
+    margin-left: 1rem !important;
+  }
+  .mx-md-4 {
+    margin-right: 1.5rem !important;
+    margin-left: 1.5rem !important;
+  }
+  .mx-md-5 {
+    margin-right: 3rem !important;
+    margin-left: 3rem !important;
+  }
+  .mx-md-auto {
+    margin-right: auto !important;
+    margin-left: auto !important;
+  }
+  .my-md-0 {
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+  }
+  .my-md-1 {
+    margin-top: 0.25rem !important;
+    margin-bottom: 0.25rem !important;
+  }
+  .my-md-2 {
+    margin-top: 0.5rem !important;
+    margin-bottom: 0.5rem !important;
+  }
+  .my-md-3 {
+    margin-top: 1rem !important;
+    margin-bottom: 1rem !important;
+  }
+  .my-md-4 {
+    margin-top: 1.5rem !important;
+    margin-bottom: 1.5rem !important;
+  }
+  .my-md-5 {
+    margin-top: 3rem !important;
+    margin-bottom: 3rem !important;
+  }
+  .my-md-auto {
+    margin-top: auto !important;
+    margin-bottom: auto !important;
+  }
+  .mt-md-0 {
+    margin-top: 0 !important;
+  }
+  .mt-md-1 {
+    margin-top: 0.25rem !important;
+  }
+  .mt-md-2 {
+    margin-top: 0.5rem !important;
+  }
+  .mt-md-3 {
+    margin-top: 1rem !important;
+  }
+  .mt-md-4 {
+    margin-top: 1.5rem !important;
+  }
+  .mt-md-5 {
+    margin-top: 3rem !important;
+  }
+  .mt-md-auto {
+    margin-top: auto !important;
+  }
+  .me-md-0 {
+    margin-right: 0 !important;
+  }
+  .me-md-1 {
+    margin-right: 0.25rem !important;
+  }
+  .me-md-2 {
+    margin-right: 0.5rem !important;
+  }
+  .me-md-3 {
+    margin-right: 1rem !important;
+  }
+  .me-md-4 {
+    margin-right: 1.5rem !important;
+  }
+  .me-md-5 {
+    margin-right: 3rem !important;
+  }
+  .me-md-auto {
+    margin-right: auto !important;
+  }
+  .mb-md-0 {
+    margin-bottom: 0 !important;
+  }
+  .mb-md-1 {
+    margin-bottom: 0.25rem !important;
+  }
+  .mb-md-2 {
+    margin-bottom: 0.5rem !important;
+  }
+  .mb-md-3 {
+    margin-bottom: 1rem !important;
+  }
+  .mb-md-4 {
+    margin-bottom: 1.5rem !important;
+  }
+  .mb-md-5 {
+    margin-bottom: 3rem !important;
+  }
+  .mb-md-auto {
+    margin-bottom: auto !important;
+  }
+  .ms-md-0 {
+    margin-left: 0 !important;
+  }
+  .ms-md-1 {
+    margin-left: 0.25rem !important;
+  }
+  .ms-md-2 {
+    margin-left: 0.5rem !important;
+  }
+  .ms-md-3 {
+    margin-left: 1rem !important;
+  }
+  .ms-md-4 {
+    margin-left: 1.5rem !important;
+  }
+  .ms-md-5 {
+    margin-left: 3rem !important;
+  }
+  .ms-md-auto {
+    margin-left: auto !important;
+  }
+  .p-md-0 {
+    padding: 0 !important;
+  }
+  .p-md-1 {
+    padding: 0.25rem !important;
+  }
+  .p-md-2 {
+    padding: 0.5rem !important;
+  }
+  .p-md-3 {
+    padding: 1rem !important;
+  }
+  .p-md-4 {
+    padding: 1.5rem !important;
+  }
+  .p-md-5 {
+    padding: 3rem !important;
+  }
+  .px-md-0 {
+    padding-right: 0 !important;
+    padding-left: 0 !important;
+  }
+  .px-md-1 {
+    padding-right: 0.25rem !important;
+    padding-left: 0.25rem !important;
+  }
+  .px-md-2 {
+    padding-right: 0.5rem !important;
+    padding-left: 0.5rem !important;
+  }
+  .px-md-3 {
+    padding-right: 1rem !important;
+    padding-left: 1rem !important;
+  }
+  .px-md-4 {
+    padding-right: 1.5rem !important;
+    padding-left: 1.5rem !important;
+  }
+  .px-md-5 {
+    padding-right: 3rem !important;
+    padding-left: 3rem !important;
+  }
+  .py-md-0 {
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+  }
+  .py-md-1 {
+    padding-top: 0.25rem !important;
+    padding-bottom: 0.25rem !important;
+  }
+  .py-md-2 {
+    padding-top: 0.5rem !important;
+    padding-bottom: 0.5rem !important;
+  }
+  .py-md-3 {
+    padding-top: 1rem !important;
+    padding-bottom: 1rem !important;
+  }
+  .py-md-4 {
+    padding-top: 1.5rem !important;
+    padding-bottom: 1.5rem !important;
+  }
+  .py-md-5 {
+    padding-top: 3rem !important;
+    padding-bottom: 3rem !important;
+  }
+  .pt-md-0 {
+    padding-top: 0 !important;
+  }
+  .pt-md-1 {
+    padding-top: 0.25rem !important;
+  }
+  .pt-md-2 {
+    padding-top: 0.5rem !important;
+  }
+  .pt-md-3 {
+    padding-top: 1rem !important;
+  }
+  .pt-md-4 {
+    padding-top: 1.5rem !important;
+  }
+  .pt-md-5 {
+    padding-top: 3rem !important;
+  }
+  .pe-md-0 {
+    padding-right: 0 !important;
+  }
+  .pe-md-1 {
+    padding-right: 0.25rem !important;
+  }
+  .pe-md-2 {
+    padding-right: 0.5rem !important;
+  }
+  .pe-md-3 {
+    padding-right: 1rem !important;
+  }
+  .pe-md-4 {
+    padding-right: 1.5rem !important;
+  }
+  .pe-md-5 {
+    padding-right: 3rem !important;
+  }
+  .pb-md-0 {
+    padding-bottom: 0 !important;
+  }
+  .pb-md-1 {
+    padding-bottom: 0.25rem !important;
+  }
+  .pb-md-2 {
+    padding-bottom: 0.5rem !important;
+  }
+  .pb-md-3 {
+    padding-bottom: 1rem !important;
+  }
+  .pb-md-4 {
+    padding-bottom: 1.5rem !important;
+  }
+  .pb-md-5 {
+    padding-bottom: 3rem !important;
+  }
+  .ps-md-0 {
+    padding-left: 0 !important;
+  }
+  .ps-md-1 {
+    padding-left: 0.25rem !important;
+  }
+  .ps-md-2 {
+    padding-left: 0.5rem !important;
+  }
+  .ps-md-3 {
+    padding-left: 1rem !important;
+  }
+  .ps-md-4 {
+    padding-left: 1.5rem !important;
+  }
+  .ps-md-5 {
+    padding-left: 3rem !important;
+  }
+  .gap-md-0 {
+    gap: 0 !important;
+  }
+  .gap-md-1 {
+    gap: 0.25rem !important;
+  }
+  .gap-md-2 {
+    gap: 0.5rem !important;
+  }
+  .gap-md-3 {
+    gap: 1rem !important;
+  }
+  .gap-md-4 {
+    gap: 1.5rem !important;
+  }
+  .gap-md-5 {
+    gap: 3rem !important;
+  }
+  .row-gap-md-0 {
+    row-gap: 0 !important;
+  }
+  .row-gap-md-1 {
+    row-gap: 0.25rem !important;
+  }
+  .row-gap-md-2 {
+    row-gap: 0.5rem !important;
+  }
+  .row-gap-md-3 {
+    row-gap: 1rem !important;
+  }
+  .row-gap-md-4 {
+    row-gap: 1.5rem !important;
+  }
+  .row-gap-md-5 {
+    row-gap: 3rem !important;
+  }
+  .column-gap-md-0 {
+    column-gap: 0 !important;
+  }
+  .column-gap-md-1 {
+    column-gap: 0.25rem !important;
+  }
+  .column-gap-md-2 {
+    column-gap: 0.5rem !important;
+  }
+  .column-gap-md-3 {
+    column-gap: 1rem !important;
+  }
+  .column-gap-md-4 {
+    column-gap: 1.5rem !important;
+  }
+  .column-gap-md-5 {
+    column-gap: 3rem !important;
+  }
+  .text-md-start {
+    text-align: left !important;
+  }
+  .text-md-end {
+    text-align: right !important;
+  }
+  .text-md-center {
+    text-align: center !important;
+  }
+}
+@media (min-width: 992px) {
+  .float-lg-start {
+    float: left !important;
+  }
+  .float-lg-end {
+    float: right !important;
+  }
+  .float-lg-none {
+    float: none !important;
+  }
+  .object-fit-lg-contain {
+    object-fit: contain !important;
+  }
+  .object-fit-lg-cover {
+    object-fit: cover !important;
+  }
+  .object-fit-lg-fill {
+    object-fit: fill !important;
+  }
+  .object-fit-lg-scale {
+    object-fit: scale-down !important;
+  }
+  .object-fit-lg-none {
+    object-fit: none !important;
+  }
+  .d-lg-inline {
+    display: inline !important;
+  }
+  .d-lg-inline-block {
+    display: inline-block !important;
+  }
+  .d-lg-block {
+    display: block !important;
+  }
+  .d-lg-grid {
+    display: grid !important;
+  }
+  .d-lg-inline-grid {
+    display: inline-grid !important;
+  }
+  .d-lg-table {
+    display: table !important;
+  }
+  .d-lg-table-row {
+    display: table-row !important;
+  }
+  .d-lg-table-cell {
+    display: table-cell !important;
+  }
+  .d-lg-flex {
+    display: flex !important;
+  }
+  .d-lg-inline-flex {
+    display: inline-flex !important;
+  }
+  .d-lg-none {
+    display: none !important;
+  }
+  .flex-lg-fill {
+    flex: 1 1 auto !important;
+  }
+  .flex-lg-row {
+    flex-direction: row !important;
+  }
+  .flex-lg-column {
+    flex-direction: column !important;
+  }
+  .flex-lg-row-reverse {
+    flex-direction: row-reverse !important;
+  }
+  .flex-lg-column-reverse {
+    flex-direction: column-reverse !important;
+  }
+  .flex-lg-grow-0 {
+    flex-grow: 0 !important;
+  }
+  .flex-lg-grow-1 {
+    flex-grow: 1 !important;
+  }
+  .flex-lg-shrink-0 {
+    flex-shrink: 0 !important;
+  }
+  .flex-lg-shrink-1 {
+    flex-shrink: 1 !important;
+  }
+  .flex-lg-wrap {
+    flex-wrap: wrap !important;
+  }
+  .flex-lg-nowrap {
+    flex-wrap: nowrap !important;
+  }
+  .flex-lg-wrap-reverse {
+    flex-wrap: wrap-reverse !important;
+  }
+  .justify-content-lg-start {
+    justify-content: flex-start !important;
+  }
+  .justify-content-lg-end {
+    justify-content: flex-end !important;
+  }
+  .justify-content-lg-center {
+    justify-content: center !important;
+  }
+  .justify-content-lg-between {
+    justify-content: space-between !important;
+  }
+  .justify-content-lg-around {
+    justify-content: space-around !important;
+  }
+  .justify-content-lg-evenly {
+    justify-content: space-evenly !important;
+  }
+  .align-items-lg-start {
+    align-items: flex-start !important;
+  }
+  .align-items-lg-end {
+    align-items: flex-end !important;
+  }
+  .align-items-lg-center {
+    align-items: center !important;
+  }
+  .align-items-lg-baseline {
+    align-items: baseline !important;
+  }
+  .align-items-lg-stretch {
+    align-items: stretch !important;
+  }
+  .align-content-lg-start {
+    align-content: flex-start !important;
+  }
+  .align-content-lg-end {
+    align-content: flex-end !important;
+  }
+  .align-content-lg-center {
+    align-content: center !important;
+  }
+  .align-content-lg-between {
+    align-content: space-between !important;
+  }
+  .align-content-lg-around {
+    align-content: space-around !important;
+  }
+  .align-content-lg-stretch {
+    align-content: stretch !important;
+  }
+  .align-self-lg-auto {
+    align-self: auto !important;
+  }
+  .align-self-lg-start {
+    align-self: flex-start !important;
+  }
+  .align-self-lg-end {
+    align-self: flex-end !important;
+  }
+  .align-self-lg-center {
+    align-self: center !important;
+  }
+  .align-self-lg-baseline {
+    align-self: baseline !important;
+  }
+  .align-self-lg-stretch {
+    align-self: stretch !important;
+  }
+  .order-lg-first {
+    order: -1 !important;
+  }
+  .order-lg-0 {
+    order: 0 !important;
+  }
+  .order-lg-1 {
+    order: 1 !important;
+  }
+  .order-lg-2 {
+    order: 2 !important;
+  }
+  .order-lg-3 {
+    order: 3 !important;
+  }
+  .order-lg-4 {
+    order: 4 !important;
+  }
+  .order-lg-5 {
+    order: 5 !important;
+  }
+  .order-lg-last {
+    order: 6 !important;
+  }
+  .m-lg-0 {
+    margin: 0 !important;
+  }
+  .m-lg-1 {
+    margin: 0.25rem !important;
+  }
+  .m-lg-2 {
+    margin: 0.5rem !important;
+  }
+  .m-lg-3 {
+    margin: 1rem !important;
+  }
+  .m-lg-4 {
+    margin: 1.5rem !important;
+  }
+  .m-lg-5 {
+    margin: 3rem !important;
+  }
+  .m-lg-auto {
+    margin: auto !important;
+  }
+  .mx-lg-0 {
+    margin-right: 0 !important;
+    margin-left: 0 !important;
+  }
+  .mx-lg-1 {
+    margin-right: 0.25rem !important;
+    margin-left: 0.25rem !important;
+  }
+  .mx-lg-2 {
+    margin-right: 0.5rem !important;
+    margin-left: 0.5rem !important;
+  }
+  .mx-lg-3 {
+    margin-right: 1rem !important;
+    margin-left: 1rem !important;
+  }
+  .mx-lg-4 {
+    margin-right: 1.5rem !important;
+    margin-left: 1.5rem !important;
+  }
+  .mx-lg-5 {
+    margin-right: 3rem !important;
+    margin-left: 3rem !important;
+  }
+  .mx-lg-auto {
+    margin-right: auto !important;
+    margin-left: auto !important;
+  }
+  .my-lg-0 {
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+  }
+  .my-lg-1 {
+    margin-top: 0.25rem !important;
+    margin-bottom: 0.25rem !important;
+  }
+  .my-lg-2 {
+    margin-top: 0.5rem !important;
+    margin-bottom: 0.5rem !important;
+  }
+  .my-lg-3 {
+    margin-top: 1rem !important;
+    margin-bottom: 1rem !important;
+  }
+  .my-lg-4 {
+    margin-top: 1.5rem !important;
+    margin-bottom: 1.5rem !important;
+  }
+  .my-lg-5 {
+    margin-top: 3rem !important;
+    margin-bottom: 3rem !important;
+  }
+  .my-lg-auto {
+    margin-top: auto !important;
+    margin-bottom: auto !important;
+  }
+  .mt-lg-0 {
+    margin-top: 0 !important;
+  }
+  .mt-lg-1 {
+    margin-top: 0.25rem !important;
+  }
+  .mt-lg-2 {
+    margin-top: 0.5rem !important;
+  }
+  .mt-lg-3 {
+    margin-top: 1rem !important;
+  }
+  .mt-lg-4 {
+    margin-top: 1.5rem !important;
+  }
+  .mt-lg-5 {
+    margin-top: 3rem !important;
+  }
+  .mt-lg-auto {
+    margin-top: auto !important;
+  }
+  .me-lg-0 {
+    margin-right: 0 !important;
+  }
+  .me-lg-1 {
+    margin-right: 0.25rem !important;
+  }
+  .me-lg-2 {
+    margin-right: 0.5rem !important;
+  }
+  .me-lg-3 {
+    margin-right: 1rem !important;
+  }
+  .me-lg-4 {
+    margin-right: 1.5rem !important;
+  }
+  .me-lg-5 {
+    margin-right: 3rem !important;
+  }
+  .me-lg-auto {
+    margin-right: auto !important;
+  }
+  .mb-lg-0 {
+    margin-bottom: 0 !important;
+  }
+  .mb-lg-1 {
+    margin-bottom: 0.25rem !important;
+  }
+  .mb-lg-2 {
+    margin-bottom: 0.5rem !important;
+  }
+  .mb-lg-3 {
+    margin-bottom: 1rem !important;
+  }
+  .mb-lg-4 {
+    margin-bottom: 1.5rem !important;
+  }
+  .mb-lg-5 {
+    margin-bottom: 3rem !important;
+  }
+  .mb-lg-auto {
+    margin-bottom: auto !important;
+  }
+  .ms-lg-0 {
+    margin-left: 0 !important;
+  }
+  .ms-lg-1 {
+    margin-left: 0.25rem !important;
+  }
+  .ms-lg-2 {
+    margin-left: 0.5rem !important;
+  }
+  .ms-lg-3 {
+    margin-left: 1rem !important;
+  }
+  .ms-lg-4 {
+    margin-left: 1.5rem !important;
+  }
+  .ms-lg-5 {
+    margin-left: 3rem !important;
+  }
+  .ms-lg-auto {
+    margin-left: auto !important;
+  }
+  .p-lg-0 {
+    padding: 0 !important;
+  }
+  .p-lg-1 {
+    padding: 0.25rem !important;
+  }
+  .p-lg-2 {
+    padding: 0.5rem !important;
+  }
+  .p-lg-3 {
+    padding: 1rem !important;
+  }
+  .p-lg-4 {
+    padding: 1.5rem !important;
+  }
+  .p-lg-5 {
+    padding: 3rem !important;
+  }
+  .px-lg-0 {
+    padding-right: 0 !important;
+    padding-left: 0 !important;
+  }
+  .px-lg-1 {
+    padding-right: 0.25rem !important;
+    padding-left: 0.25rem !important;
+  }
+  .px-lg-2 {
+    padding-right: 0.5rem !important;
+    padding-left: 0.5rem !important;
+  }
+  .px-lg-3 {
+    padding-right: 1rem !important;
+    padding-left: 1rem !important;
+  }
+  .px-lg-4 {
+    padding-right: 1.5rem !important;
+    padding-left: 1.5rem !important;
+  }
+  .px-lg-5 {
+    padding-right: 3rem !important;
+    padding-left: 3rem !important;
+  }
+  .py-lg-0 {
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+  }
+  .py-lg-1 {
+    padding-top: 0.25rem !important;
+    padding-bottom: 0.25rem !important;
+  }
+  .py-lg-2 {
+    padding-top: 0.5rem !important;
+    padding-bottom: 0.5rem !important;
+  }
+  .py-lg-3 {
+    padding-top: 1rem !important;
+    padding-bottom: 1rem !important;
+  }
+  .py-lg-4 {
+    padding-top: 1.5rem !important;
+    padding-bottom: 1.5rem !important;
+  }
+  .py-lg-5 {
+    padding-top: 3rem !important;
+    padding-bottom: 3rem !important;
+  }
+  .pt-lg-0 {
+    padding-top: 0 !important;
+  }
+  .pt-lg-1 {
+    padding-top: 0.25rem !important;
+  }
+  .pt-lg-2 {
+    padding-top: 0.5rem !important;
+  }
+  .pt-lg-3 {
+    padding-top: 1rem !important;
+  }
+  .pt-lg-4 {
+    padding-top: 1.5rem !important;
+  }
+  .pt-lg-5 {
+    padding-top: 3rem !important;
+  }
+  .pe-lg-0 {
+    padding-right: 0 !important;
+  }
+  .pe-lg-1 {
+    padding-right: 0.25rem !important;
+  }
+  .pe-lg-2 {
+    padding-right: 0.5rem !important;
+  }
+  .pe-lg-3 {
+    padding-right: 1rem !important;
+  }
+  .pe-lg-4 {
+    padding-right: 1.5rem !important;
+  }
+  .pe-lg-5 {
+    padding-right: 3rem !important;
+  }
+  .pb-lg-0 {
+    padding-bottom: 0 !important;
+  }
+  .pb-lg-1 {
+    padding-bottom: 0.25rem !important;
+  }
+  .pb-lg-2 {
+    padding-bottom: 0.5rem !important;
+  }
+  .pb-lg-3 {
+    padding-bottom: 1rem !important;
+  }
+  .pb-lg-4 {
+    padding-bottom: 1.5rem !important;
+  }
+  .pb-lg-5 {
+    padding-bottom: 3rem !important;
+  }
+  .ps-lg-0 {
+    padding-left: 0 !important;
+  }
+  .ps-lg-1 {
+    padding-left: 0.25rem !important;
+  }
+  .ps-lg-2 {
+    padding-left: 0.5rem !important;
+  }
+  .ps-lg-3 {
+    padding-left: 1rem !important;
+  }
+  .ps-lg-4 {
+    padding-left: 1.5rem !important;
+  }
+  .ps-lg-5 {
+    padding-left: 3rem !important;
+  }
+  .gap-lg-0 {
+    gap: 0 !important;
+  }
+  .gap-lg-1 {
+    gap: 0.25rem !important;
+  }
+  .gap-lg-2 {
+    gap: 0.5rem !important;
+  }
+  .gap-lg-3 {
+    gap: 1rem !important;
+  }
+  .gap-lg-4 {
+    gap: 1.5rem !important;
+  }
+  .gap-lg-5 {
+    gap: 3rem !important;
+  }
+  .row-gap-lg-0 {
+    row-gap: 0 !important;
+  }
+  .row-gap-lg-1 {
+    row-gap: 0.25rem !important;
+  }
+  .row-gap-lg-2 {
+    row-gap: 0.5rem !important;
+  }
+  .row-gap-lg-3 {
+    row-gap: 1rem !important;
+  }
+  .row-gap-lg-4 {
+    row-gap: 1.5rem !important;
+  }
+  .row-gap-lg-5 {
+    row-gap: 3rem !important;
+  }
+  .column-gap-lg-0 {
+    column-gap: 0 !important;
+  }
+  .column-gap-lg-1 {
+    column-gap: 0.25rem !important;
+  }
+  .column-gap-lg-2 {
+    column-gap: 0.5rem !important;
+  }
+  .column-gap-lg-3 {
+    column-gap: 1rem !important;
+  }
+  .column-gap-lg-4 {
+    column-gap: 1.5rem !important;
+  }
+  .column-gap-lg-5 {
+    column-gap: 3rem !important;
+  }
+  .text-lg-start {
+    text-align: left !important;
+  }
+  .text-lg-end {
+    text-align: right !important;
+  }
+  .text-lg-center {
+    text-align: center !important;
+  }
+}
+@media (min-width: 1200px) {
+  .float-xl-start {
+    float: left !important;
+  }
+  .float-xl-end {
+    float: right !important;
+  }
+  .float-xl-none {
+    float: none !important;
+  }
+  .object-fit-xl-contain {
+    object-fit: contain !important;
+  }
+  .object-fit-xl-cover {
+    object-fit: cover !important;
+  }
+  .object-fit-xl-fill {
+    object-fit: fill !important;
+  }
+  .object-fit-xl-scale {
+    object-fit: scale-down !important;
+  }
+  .object-fit-xl-none {
+    object-fit: none !important;
+  }
+  .d-xl-inline {
+    display: inline !important;
+  }
+  .d-xl-inline-block {
+    display: inline-block !important;
+  }
+  .d-xl-block {
+    display: block !important;
+  }
+  .d-xl-grid {
+    display: grid !important;
+  }
+  .d-xl-inline-grid {
+    display: inline-grid !important;
+  }
+  .d-xl-table {
+    display: table !important;
+  }
+  .d-xl-table-row {
+    display: table-row !important;
+  }
+  .d-xl-table-cell {
+    display: table-cell !important;
+  }
+  .d-xl-flex {
+    display: flex !important;
+  }
+  .d-xl-inline-flex {
+    display: inline-flex !important;
+  }
+  .d-xl-none {
+    display: none !important;
+  }
+  .flex-xl-fill {
+    flex: 1 1 auto !important;
+  }
+  .flex-xl-row {
+    flex-direction: row !important;
+  }
+  .flex-xl-column {
+    flex-direction: column !important;
+  }
+  .flex-xl-row-reverse {
+    flex-direction: row-reverse !important;
+  }
+  .flex-xl-column-reverse {
+    flex-direction: column-reverse !important;
+  }
+  .flex-xl-grow-0 {
+    flex-grow: 0 !important;
+  }
+  .flex-xl-grow-1 {
+    flex-grow: 1 !important;
+  }
+  .flex-xl-shrink-0 {
+    flex-shrink: 0 !important;
+  }
+  .flex-xl-shrink-1 {
+    flex-shrink: 1 !important;
+  }
+  .flex-xl-wrap {
+    flex-wrap: wrap !important;
+  }
+  .flex-xl-nowrap {
+    flex-wrap: nowrap !important;
+  }
+  .flex-xl-wrap-reverse {
+    flex-wrap: wrap-reverse !important;
+  }
+  .justify-content-xl-start {
+    justify-content: flex-start !important;
+  }
+  .justify-content-xl-end {
+    justify-content: flex-end !important;
+  }
+  .justify-content-xl-center {
+    justify-content: center !important;
+  }
+  .justify-content-xl-between {
+    justify-content: space-between !important;
+  }
+  .justify-content-xl-around {
+    justify-content: space-around !important;
+  }
+  .justify-content-xl-evenly {
+    justify-content: space-evenly !important;
+  }
+  .align-items-xl-start {
+    align-items: flex-start !important;
+  }
+  .align-items-xl-end {
+    align-items: flex-end !important;
+  }
+  .align-items-xl-center {
+    align-items: center !important;
+  }
+  .align-items-xl-baseline {
+    align-items: baseline !important;
+  }
+  .align-items-xl-stretch {
+    align-items: stretch !important;
+  }
+  .align-content-xl-start {
+    align-content: flex-start !important;
+  }
+  .align-content-xl-end {
+    align-content: flex-end !important;
+  }
+  .align-content-xl-center {
+    align-content: center !important;
+  }
+  .align-content-xl-between {
+    align-content: space-between !important;
+  }
+  .align-content-xl-around {
+    align-content: space-around !important;
+  }
+  .align-content-xl-stretch {
+    align-content: stretch !important;
+  }
+  .align-self-xl-auto {
+    align-self: auto !important;
+  }
+  .align-self-xl-start {
+    align-self: flex-start !important;
+  }
+  .align-self-xl-end {
+    align-self: flex-end !important;
+  }
+  .align-self-xl-center {
+    align-self: center !important;
+  }
+  .align-self-xl-baseline {
+    align-self: baseline !important;
+  }
+  .align-self-xl-stretch {
+    align-self: stretch !important;
+  }
+  .order-xl-first {
+    order: -1 !important;
+  }
+  .order-xl-0 {
+    order: 0 !important;
+  }
+  .order-xl-1 {
+    order: 1 !important;
+  }
+  .order-xl-2 {
+    order: 2 !important;
+  }
+  .order-xl-3 {
+    order: 3 !important;
+  }
+  .order-xl-4 {
+    order: 4 !important;
+  }
+  .order-xl-5 {
+    order: 5 !important;
+  }
+  .order-xl-last {
+    order: 6 !important;
+  }
+  .m-xl-0 {
+    margin: 0 !important;
+  }
+  .m-xl-1 {
+    margin: 0.25rem !important;
+  }
+  .m-xl-2 {
+    margin: 0.5rem !important;
+  }
+  .m-xl-3 {
+    margin: 1rem !important;
+  }
+  .m-xl-4 {
+    margin: 1.5rem !important;
+  }
+  .m-xl-5 {
+    margin: 3rem !important;
+  }
+  .m-xl-auto {
+    margin: auto !important;
+  }
+  .mx-xl-0 {
+    margin-right: 0 !important;
+    margin-left: 0 !important;
+  }
+  .mx-xl-1 {
+    margin-right: 0.25rem !important;
+    margin-left: 0.25rem !important;
+  }
+  .mx-xl-2 {
+    margin-right: 0.5rem !important;
+    margin-left: 0.5rem !important;
+  }
+  .mx-xl-3 {
+    margin-right: 1rem !important;
+    margin-left: 1rem !important;
+  }
+  .mx-xl-4 {
+    margin-right: 1.5rem !important;
+    margin-left: 1.5rem !important;
+  }
+  .mx-xl-5 {
+    margin-right: 3rem !important;
+    margin-left: 3rem !important;
+  }
+  .mx-xl-auto {
+    margin-right: auto !important;
+    margin-left: auto !important;
+  }
+  .my-xl-0 {
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+  }
+  .my-xl-1 {
+    margin-top: 0.25rem !important;
+    margin-bottom: 0.25rem !important;
+  }
+  .my-xl-2 {
+    margin-top: 0.5rem !important;
+    margin-bottom: 0.5rem !important;
+  }
+  .my-xl-3 {
+    margin-top: 1rem !important;
+    margin-bottom: 1rem !important;
+  }
+  .my-xl-4 {
+    margin-top: 1.5rem !important;
+    margin-bottom: 1.5rem !important;
+  }
+  .my-xl-5 {
+    margin-top: 3rem !important;
+    margin-bottom: 3rem !important;
+  }
+  .my-xl-auto {
+    margin-top: auto !important;
+    margin-bottom: auto !important;
+  }
+  .mt-xl-0 {
+    margin-top: 0 !important;
+  }
+  .mt-xl-1 {
+    margin-top: 0.25rem !important;
+  }
+  .mt-xl-2 {
+    margin-top: 0.5rem !important;
+  }
+  .mt-xl-3 {
+    margin-top: 1rem !important;
+  }
+  .mt-xl-4 {
+    margin-top: 1.5rem !important;
+  }
+  .mt-xl-5 {
+    margin-top: 3rem !important;
+  }
+  .mt-xl-auto {
+    margin-top: auto !important;
+  }
+  .me-xl-0 {
+    margin-right: 0 !important;
+  }
+  .me-xl-1 {
+    margin-right: 0.25rem !important;
+  }
+  .me-xl-2 {
+    margin-right: 0.5rem !important;
+  }
+  .me-xl-3 {
+    margin-right: 1rem !important;
+  }
+  .me-xl-4 {
+    margin-right: 1.5rem !important;
+  }
+  .me-xl-5 {
+    margin-right: 3rem !important;
+  }
+  .me-xl-auto {
+    margin-right: auto !important;
+  }
+  .mb-xl-0 {
+    margin-bottom: 0 !important;
+  }
+  .mb-xl-1 {
+    margin-bottom: 0.25rem !important;
+  }
+  .mb-xl-2 {
+    margin-bottom: 0.5rem !important;
+  }
+  .mb-xl-3 {
+    margin-bottom: 1rem !important;
+  }
+  .mb-xl-4 {
+    margin-bottom: 1.5rem !important;
+  }
+  .mb-xl-5 {
+    margin-bottom: 3rem !important;
+  }
+  .mb-xl-auto {
+    margin-bottom: auto !important;
+  }
+  .ms-xl-0 {
+    margin-left: 0 !important;
+  }
+  .ms-xl-1 {
+    margin-left: 0.25rem !important;
+  }
+  .ms-xl-2 {
+    margin-left: 0.5rem !important;
+  }
+  .ms-xl-3 {
+    margin-left: 1rem !important;
+  }
+  .ms-xl-4 {
+    margin-left: 1.5rem !important;
+  }
+  .ms-xl-5 {
+    margin-left: 3rem !important;
+  }
+  .ms-xl-auto {
+    margin-left: auto !important;
+  }
+  .p-xl-0 {
+    padding: 0 !important;
+  }
+  .p-xl-1 {
+    padding: 0.25rem !important;
+  }
+  .p-xl-2 {
+    padding: 0.5rem !important;
+  }
+  .p-xl-3 {
+    padding: 1rem !important;
+  }
+  .p-xl-4 {
+    padding: 1.5rem !important;
+  }
+  .p-xl-5 {
+    padding: 3rem !important;
+  }
+  .px-xl-0 {
+    padding-right: 0 !important;
+    padding-left: 0 !important;
+  }
+  .px-xl-1 {
+    padding-right: 0.25rem !important;
+    padding-left: 0.25rem !important;
+  }
+  .px-xl-2 {
+    padding-right: 0.5rem !important;
+    padding-left: 0.5rem !important;
+  }
+  .px-xl-3 {
+    padding-right: 1rem !important;
+    padding-left: 1rem !important;
+  }
+  .px-xl-4 {
+    padding-right: 1.5rem !important;
+    padding-left: 1.5rem !important;
+  }
+  .px-xl-5 {
+    padding-right: 3rem !important;
+    padding-left: 3rem !important;
+  }
+  .py-xl-0 {
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+  }
+  .py-xl-1 {
+    padding-top: 0.25rem !important;
+    padding-bottom: 0.25rem !important;
+  }
+  .py-xl-2 {
+    padding-top: 0.5rem !important;
+    padding-bottom: 0.5rem !important;
+  }
+  .py-xl-3 {
+    padding-top: 1rem !important;
+    padding-bottom: 1rem !important;
+  }
+  .py-xl-4 {
+    padding-top: 1.5rem !important;
+    padding-bottom: 1.5rem !important;
+  }
+  .py-xl-5 {
+    padding-top: 3rem !important;
+    padding-bottom: 3rem !important;
+  }
+  .pt-xl-0 {
+    padding-top: 0 !important;
+  }
+  .pt-xl-1 {
+    padding-top: 0.25rem !important;
+  }
+  .pt-xl-2 {
+    padding-top: 0.5rem !important;
+  }
+  .pt-xl-3 {
+    padding-top: 1rem !important;
+  }
+  .pt-xl-4 {
+    padding-top: 1.5rem !important;
+  }
+  .pt-xl-5 {
+    padding-top: 3rem !important;
+  }
+  .pe-xl-0 {
+    padding-right: 0 !important;
+  }
+  .pe-xl-1 {
+    padding-right: 0.25rem !important;
+  }
+  .pe-xl-2 {
+    padding-right: 0.5rem !important;
+  }
+  .pe-xl-3 {
+    padding-right: 1rem !important;
+  }
+  .pe-xl-4 {
+    padding-right: 1.5rem !important;
+  }
+  .pe-xl-5 {
+    padding-right: 3rem !important;
+  }
+  .pb-xl-0 {
+    padding-bottom: 0 !important;
+  }
+  .pb-xl-1 {
+    padding-bottom: 0.25rem !important;
+  }
+  .pb-xl-2 {
+    padding-bottom: 0.5rem !important;
+  }
+  .pb-xl-3 {
+    padding-bottom: 1rem !important;
+  }
+  .pb-xl-4 {
+    padding-bottom: 1.5rem !important;
+  }
+  .pb-xl-5 {
+    padding-bottom: 3rem !important;
+  }
+  .ps-xl-0 {
+    padding-left: 0 !important;
+  }
+  .ps-xl-1 {
+    padding-left: 0.25rem !important;
+  }
+  .ps-xl-2 {
+    padding-left: 0.5rem !important;
+  }
+  .ps-xl-3 {
+    padding-left: 1rem !important;
+  }
+  .ps-xl-4 {
+    padding-left: 1.5rem !important;
+  }
+  .ps-xl-5 {
+    padding-left: 3rem !important;
+  }
+  .gap-xl-0 {
+    gap: 0 !important;
+  }
+  .gap-xl-1 {
+    gap: 0.25rem !important;
+  }
+  .gap-xl-2 {
+    gap: 0.5rem !important;
+  }
+  .gap-xl-3 {
+    gap: 1rem !important;
+  }
+  .gap-xl-4 {
+    gap: 1.5rem !important;
+  }
+  .gap-xl-5 {
+    gap: 3rem !important;
+  }
+  .row-gap-xl-0 {
+    row-gap: 0 !important;
+  }
+  .row-gap-xl-1 {
+    row-gap: 0.25rem !important;
+  }
+  .row-gap-xl-2 {
+    row-gap: 0.5rem !important;
+  }
+  .row-gap-xl-3 {
+    row-gap: 1rem !important;
+  }
+  .row-gap-xl-4 {
+    row-gap: 1.5rem !important;
+  }
+  .row-gap-xl-5 {
+    row-gap: 3rem !important;
+  }
+  .column-gap-xl-0 {
+    column-gap: 0 !important;
+  }
+  .column-gap-xl-1 {
+    column-gap: 0.25rem !important;
+  }
+  .column-gap-xl-2 {
+    column-gap: 0.5rem !important;
+  }
+  .column-gap-xl-3 {
+    column-gap: 1rem !important;
+  }
+  .column-gap-xl-4 {
+    column-gap: 1.5rem !important;
+  }
+  .column-gap-xl-5 {
+    column-gap: 3rem !important;
+  }
+  .text-xl-start {
+    text-align: left !important;
+  }
+  .text-xl-end {
+    text-align: right !important;
+  }
+  .text-xl-center {
+    text-align: center !important;
+  }
+}
+@media (min-width: 1400px) {
+  .float-xxl-start {
+    float: left !important;
+  }
+  .float-xxl-end {
+    float: right !important;
+  }
+  .float-xxl-none {
+    float: none !important;
+  }
+  .object-fit-xxl-contain {
+    object-fit: contain !important;
+  }
+  .object-fit-xxl-cover {
+    object-fit: cover !important;
+  }
+  .object-fit-xxl-fill {
+    object-fit: fill !important;
+  }
+  .object-fit-xxl-scale {
+    object-fit: scale-down !important;
+  }
+  .object-fit-xxl-none {
+    object-fit: none !important;
+  }
+  .d-xxl-inline {
+    display: inline !important;
+  }
+  .d-xxl-inline-block {
+    display: inline-block !important;
+  }
+  .d-xxl-block {
+    display: block !important;
+  }
+  .d-xxl-grid {
+    display: grid !important;
+  }
+  .d-xxl-inline-grid {
+    display: inline-grid !important;
+  }
+  .d-xxl-table {
+    display: table !important;
+  }
+  .d-xxl-table-row {
+    display: table-row !important;
+  }
+  .d-xxl-table-cell {
+    display: table-cell !important;
+  }
+  .d-xxl-flex {
+    display: flex !important;
+  }
+  .d-xxl-inline-flex {
+    display: inline-flex !important;
+  }
+  .d-xxl-none {
+    display: none !important;
+  }
+  .flex-xxl-fill {
+    flex: 1 1 auto !important;
+  }
+  .flex-xxl-row {
+    flex-direction: row !important;
+  }
+  .flex-xxl-column {
+    flex-direction: column !important;
+  }
+  .flex-xxl-row-reverse {
+    flex-direction: row-reverse !important;
+  }
+  .flex-xxl-column-reverse {
+    flex-direction: column-reverse !important;
+  }
+  .flex-xxl-grow-0 {
+    flex-grow: 0 !important;
+  }
+  .flex-xxl-grow-1 {
+    flex-grow: 1 !important;
+  }
+  .flex-xxl-shrink-0 {
+    flex-shrink: 0 !important;
+  }
+  .flex-xxl-shrink-1 {
+    flex-shrink: 1 !important;
+  }
+  .flex-xxl-wrap {
+    flex-wrap: wrap !important;
+  }
+  .flex-xxl-nowrap {
+    flex-wrap: nowrap !important;
+  }
+  .flex-xxl-wrap-reverse {
+    flex-wrap: wrap-reverse !important;
+  }
+  .justify-content-xxl-start {
+    justify-content: flex-start !important;
+  }
+  .justify-content-xxl-end {
+    justify-content: flex-end !important;
+  }
+  .justify-content-xxl-center {
+    justify-content: center !important;
+  }
+  .justify-content-xxl-between {
+    justify-content: space-between !important;
+  }
+  .justify-content-xxl-around {
+    justify-content: space-around !important;
+  }
+  .justify-content-xxl-evenly {
+    justify-content: space-evenly !important;
+  }
+  .align-items-xxl-start {
+    align-items: flex-start !important;
+  }
+  .align-items-xxl-end {
+    align-items: flex-end !important;
+  }
+  .align-items-xxl-center {
+    align-items: center !important;
+  }
+  .align-items-xxl-baseline {
+    align-items: baseline !important;
+  }
+  .align-items-xxl-stretch {
+    align-items: stretch !important;
+  }
+  .align-content-xxl-start {
+    align-content: flex-start !important;
+  }
+  .align-content-xxl-end {
+    align-content: flex-end !important;
+  }
+  .align-content-xxl-center {
+    align-content: center !important;
+  }
+  .align-content-xxl-between {
+    align-content: space-between !important;
+  }
+  .align-content-xxl-around {
+    align-content: space-around !important;
+  }
+  .align-content-xxl-stretch {
+    align-content: stretch !important;
+  }
+  .align-self-xxl-auto {
+    align-self: auto !important;
+  }
+  .align-self-xxl-start {
+    align-self: flex-start !important;
+  }
+  .align-self-xxl-end {
+    align-self: flex-end !important;
+  }
+  .align-self-xxl-center {
+    align-self: center !important;
+  }
+  .align-self-xxl-baseline {
+    align-self: baseline !important;
+  }
+  .align-self-xxl-stretch {
+    align-self: stretch !important;
+  }
+  .order-xxl-first {
+    order: -1 !important;
+  }
+  .order-xxl-0 {
+    order: 0 !important;
+  }
+  .order-xxl-1 {
+    order: 1 !important;
+  }
+  .order-xxl-2 {
+    order: 2 !important;
+  }
+  .order-xxl-3 {
+    order: 3 !important;
+  }
+  .order-xxl-4 {
+    order: 4 !important;
+  }
+  .order-xxl-5 {
+    order: 5 !important;
+  }
+  .order-xxl-last {
+    order: 6 !important;
+  }
+  .m-xxl-0 {
+    margin: 0 !important;
+  }
+  .m-xxl-1 {
+    margin: 0.25rem !important;
+  }
+  .m-xxl-2 {
+    margin: 0.5rem !important;
+  }
+  .m-xxl-3 {
+    margin: 1rem !important;
+  }
+  .m-xxl-4 {
+    margin: 1.5rem !important;
+  }
+  .m-xxl-5 {
+    margin: 3rem !important;
+  }
+  .m-xxl-auto {
+    margin: auto !important;
+  }
+  .mx-xxl-0 {
+    margin-right: 0 !important;
+    margin-left: 0 !important;
+  }
+  .mx-xxl-1 {
+    margin-right: 0.25rem !important;
+    margin-left: 0.25rem !important;
+  }
+  .mx-xxl-2 {
+    margin-right: 0.5rem !important;
+    margin-left: 0.5rem !important;
+  }
+  .mx-xxl-3 {
+    margin-right: 1rem !important;
+    margin-left: 1rem !important;
+  }
+  .mx-xxl-4 {
+    margin-right: 1.5rem !important;
+    margin-left: 1.5rem !important;
+  }
+  .mx-xxl-5 {
+    margin-right: 3rem !important;
+    margin-left: 3rem !important;
+  }
+  .mx-xxl-auto {
+    margin-right: auto !important;
+    margin-left: auto !important;
+  }
+  .my-xxl-0 {
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+  }
+  .my-xxl-1 {
+    margin-top: 0.25rem !important;
+    margin-bottom: 0.25rem !important;
+  }
+  .my-xxl-2 {
+    margin-top: 0.5rem !important;
+    margin-bottom: 0.5rem !important;
+  }
+  .my-xxl-3 {
+    margin-top: 1rem !important;
+    margin-bottom: 1rem !important;
+  }
+  .my-xxl-4 {
+    margin-top: 1.5rem !important;
+    margin-bottom: 1.5rem !important;
+  }
+  .my-xxl-5 {
+    margin-top: 3rem !important;
+    margin-bottom: 3rem !important;
+  }
+  .my-xxl-auto {
+    margin-top: auto !important;
+    margin-bottom: auto !important;
+  }
+  .mt-xxl-0 {
+    margin-top: 0 !important;
+  }
+  .mt-xxl-1 {
+    margin-top: 0.25rem !important;
+  }
+  .mt-xxl-2 {
+    margin-top: 0.5rem !important;
+  }
+  .mt-xxl-3 {
+    margin-top: 1rem !important;
+  }
+  .mt-xxl-4 {
+    margin-top: 1.5rem !important;
+  }
+  .mt-xxl-5 {
+    margin-top: 3rem !important;
+  }
+  .mt-xxl-auto {
+    margin-top: auto !important;
+  }
+  .me-xxl-0 {
+    margin-right: 0 !important;
+  }
+  .me-xxl-1 {
+    margin-right: 0.25rem !important;
+  }
+  .me-xxl-2 {
+    margin-right: 0.5rem !important;
+  }
+  .me-xxl-3 {
+    margin-right: 1rem !important;
+  }
+  .me-xxl-4 {
+    margin-right: 1.5rem !important;
+  }
+  .me-xxl-5 {
+    margin-right: 3rem !important;
+  }
+  .me-xxl-auto {
+    margin-right: auto !important;
+  }
+  .mb-xxl-0 {
+    margin-bottom: 0 !important;
+  }
+  .mb-xxl-1 {
+    margin-bottom: 0.25rem !important;
+  }
+  .mb-xxl-2 {
+    margin-bottom: 0.5rem !important;
+  }
+  .mb-xxl-3 {
+    margin-bottom: 1rem !important;
+  }
+  .mb-xxl-4 {
+    margin-bottom: 1.5rem !important;
+  }
+  .mb-xxl-5 {
+    margin-bottom: 3rem !important;
+  }
+  .mb-xxl-auto {
+    margin-bottom: auto !important;
+  }
+  .ms-xxl-0 {
+    margin-left: 0 !important;
+  }
+  .ms-xxl-1 {
+    margin-left: 0.25rem !important;
+  }
+  .ms-xxl-2 {
+    margin-left: 0.5rem !important;
+  }
+  .ms-xxl-3 {
+    margin-left: 1rem !important;
+  }
+  .ms-xxl-4 {
+    margin-left: 1.5rem !important;
+  }
+  .ms-xxl-5 {
+    margin-left: 3rem !important;
+  }
+  .ms-xxl-auto {
+    margin-left: auto !important;
+  }
+  .p-xxl-0 {
+    padding: 0 !important;
+  }
+  .p-xxl-1 {
+    padding: 0.25rem !important;
+  }
+  .p-xxl-2 {
+    padding: 0.5rem !important;
+  }
+  .p-xxl-3 {
+    padding: 1rem !important;
+  }
+  .p-xxl-4 {
+    padding: 1.5rem !important;
+  }
+  .p-xxl-5 {
+    padding: 3rem !important;
+  }
+  .px-xxl-0 {
+    padding-right: 0 !important;
+    padding-left: 0 !important;
+  }
+  .px-xxl-1 {
+    padding-right: 0.25rem !important;
+    padding-left: 0.25rem !important;
+  }
+  .px-xxl-2 {
+    padding-right: 0.5rem !important;
+    padding-left: 0.5rem !important;
+  }
+  .px-xxl-3 {
+    padding-right: 1rem !important;
+    padding-left: 1rem !important;
+  }
+  .px-xxl-4 {
+    padding-right: 1.5rem !important;
+    padding-left: 1.5rem !important;
+  }
+  .px-xxl-5 {
+    padding-right: 3rem !important;
+    padding-left: 3rem !important;
+  }
+  .py-xxl-0 {
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+  }
+  .py-xxl-1 {
+    padding-top: 0.25rem !important;
+    padding-bottom: 0.25rem !important;
+  }
+  .py-xxl-2 {
+    padding-top: 0.5rem !important;
+    padding-bottom: 0.5rem !important;
+  }
+  .py-xxl-3 {
+    padding-top: 1rem !important;
+    padding-bottom: 1rem !important;
+  }
+  .py-xxl-4 {
+    padding-top: 1.5rem !important;
+    padding-bottom: 1.5rem !important;
+  }
+  .py-xxl-5 {
+    padding-top: 3rem !important;
+    padding-bottom: 3rem !important;
+  }
+  .pt-xxl-0 {
+    padding-top: 0 !important;
+  }
+  .pt-xxl-1 {
+    padding-top: 0.25rem !important;
+  }
+  .pt-xxl-2 {
+    padding-top: 0.5rem !important;
+  }
+  .pt-xxl-3 {
+    padding-top: 1rem !important;
+  }
+  .pt-xxl-4 {
+    padding-top: 1.5rem !important;
+  }
+  .pt-xxl-5 {
+    padding-top: 3rem !important;
+  }
+  .pe-xxl-0 {
+    padding-right: 0 !important;
+  }
+  .pe-xxl-1 {
+    padding-right: 0.25rem !important;
+  }
+  .pe-xxl-2 {
+    padding-right: 0.5rem !important;
+  }
+  .pe-xxl-3 {
+    padding-right: 1rem !important;
+  }
+  .pe-xxl-4 {
+    padding-right: 1.5rem !important;
+  }
+  .pe-xxl-5 {
+    padding-right: 3rem !important;
+  }
+  .pb-xxl-0 {
+    padding-bottom: 0 !important;
+  }
+  .pb-xxl-1 {
+    padding-bottom: 0.25rem !important;
+  }
+  .pb-xxl-2 {
+    padding-bottom: 0.5rem !important;
+  }
+  .pb-xxl-3 {
+    padding-bottom: 1rem !important;
+  }
+  .pb-xxl-4 {
+    padding-bottom: 1.5rem !important;
+  }
+  .pb-xxl-5 {
+    padding-bottom: 3rem !important;
+  }
+  .ps-xxl-0 {
+    padding-left: 0 !important;
+  }
+  .ps-xxl-1 {
+    padding-left: 0.25rem !important;
+  }
+  .ps-xxl-2 {
+    padding-left: 0.5rem !important;
+  }
+  .ps-xxl-3 {
+    padding-left: 1rem !important;
+  }
+  .ps-xxl-4 {
+    padding-left: 1.5rem !important;
+  }
+  .ps-xxl-5 {
+    padding-left: 3rem !important;
+  }
+  .gap-xxl-0 {
+    gap: 0 !important;
+  }
+  .gap-xxl-1 {
+    gap: 0.25rem !important;
+  }
+  .gap-xxl-2 {
+    gap: 0.5rem !important;
+  }
+  .gap-xxl-3 {
+    gap: 1rem !important;
+  }
+  .gap-xxl-4 {
+    gap: 1.5rem !important;
+  }
+  .gap-xxl-5 {
+    gap: 3rem !important;
+  }
+  .row-gap-xxl-0 {
+    row-gap: 0 !important;
+  }
+  .row-gap-xxl-1 {
+    row-gap: 0.25rem !important;
+  }
+  .row-gap-xxl-2 {
+    row-gap: 0.5rem !important;
+  }
+  .row-gap-xxl-3 {
+    row-gap: 1rem !important;
+  }
+  .row-gap-xxl-4 {
+    row-gap: 1.5rem !important;
+  }
+  .row-gap-xxl-5 {
+    row-gap: 3rem !important;
+  }
+  .column-gap-xxl-0 {
+    column-gap: 0 !important;
+  }
+  .column-gap-xxl-1 {
+    column-gap: 0.25rem !important;
+  }
+  .column-gap-xxl-2 {
+    column-gap: 0.5rem !important;
+  }
+  .column-gap-xxl-3 {
+    column-gap: 1rem !important;
+  }
+  .column-gap-xxl-4 {
+    column-gap: 1.5rem !important;
+  }
+  .column-gap-xxl-5 {
+    column-gap: 3rem !important;
+  }
+  .text-xxl-start {
+    text-align: left !important;
+  }
+  .text-xxl-end {
+    text-align: right !important;
+  }
+  .text-xxl-center {
+    text-align: center !important;
+  }
+}
+@media (min-width: 1200px) {
+  .fs-1 {
+    font-size: 2.5rem !important;
+  }
+  .fs-2 {
+    font-size: 2rem !important;
+  }
+  .fs-3 {
+    font-size: 1.75rem !important;
+  }
+  .fs-4 {
+    font-size: 1.5rem !important;
+  }
+}
+@media print {
+  .d-print-inline {
+    display: inline !important;
+  }
+  .d-print-inline-block {
+    display: inline-block !important;
+  }
+  .d-print-block {
+    display: block !important;
+  }
+  .d-print-grid {
+    display: grid !important;
+  }
+  .d-print-inline-grid {
+    display: inline-grid !important;
+  }
+  .d-print-table {
+    display: table !important;
+  }
+  .d-print-table-row {
+    display: table-row !important;
+  }
+  .d-print-table-cell {
+    display: table-cell !important;
+  }
+  .d-print-flex {
+    display: flex !important;
+  }
+  .d-print-inline-flex {
+    display: inline-flex !important;
+  }
+  .d-print-none {
+    display: none !important;
+  }
+}
+/*!
+ * Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+ * Copyright 2024 Fonticons, Inc.
+ */
+.fa {
+  font-family: var(--fa-style-family, "Font Awesome 6 Free");
+  font-weight: var(--fa-style, 900);
+}
+
+.fas,
+.far,
+.fab,
+.fa-solid,
+.fa-regular,
+.fa-brands,
+.fa {
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: var(--fa-display, inline-block);
+  font-style: normal;
+  font-variant: normal;
+  line-height: 1;
+  text-rendering: auto;
+}
+
+.fas::before,
+.far::before,
+.fab::before,
+.fa-solid::before,
+.fa-regular::before,
+.fa-brands::before,
+.fa::before {
+  content: var(--fa);
+}
+
+.fa-classic,
+.fas,
+.fa-solid,
+.far,
+.fa-regular {
+  font-family: "Font Awesome 6 Free";
+}
+
+.fa-brands,
+.fab {
+  font-family: "Font Awesome 6 Brands";
+}
+
+.fa-1x {
+  font-size: 1em;
+}
+
+.fa-2x {
+  font-size: 2em;
+}
+
+.fa-3x {
+  font-size: 3em;
+}
+
+.fa-4x {
+  font-size: 4em;
+}
+
+.fa-5x {
+  font-size: 5em;
+}
+
+.fa-6x {
+  font-size: 6em;
+}
+
+.fa-7x {
+  font-size: 7em;
+}
+
+.fa-8x {
+  font-size: 8em;
+}
+
+.fa-9x {
+  font-size: 9em;
+}
+
+.fa-10x {
+  font-size: 10em;
+}
+
+.fa-2xs {
+  font-size: 0.625em;
+  line-height: 0.1em;
+  vertical-align: 0.225em;
+}
+
+.fa-xs {
+  font-size: 0.75em;
+  line-height: 0.0833333337em;
+  vertical-align: 0.125em;
+}
+
+.fa-sm {
+  font-size: 0.875em;
+  line-height: 0.0714285718em;
+  vertical-align: 0.0535714295em;
+}
+
+.fa-lg {
+  font-size: 1.25em;
+  line-height: 0.05em;
+  vertical-align: -0.075em;
+}
+
+.fa-xl {
+  font-size: 1.5em;
+  line-height: 0.0416666682em;
+  vertical-align: -0.125em;
+}
+
+.fa-2xl {
+  font-size: 2em;
+  line-height: 0.03125em;
+  vertical-align: -0.1875em;
+}
+
+.fa-fw {
+  text-align: center;
+  width: 1.25em;
+}
+
+.fa-ul {
+  list-style-type: none;
+  margin-left: var(--fa-li-margin, 2.5em);
+  padding-left: 0;
+}
+.fa-ul > li {
+  position: relative;
+}
+
+.fa-li {
+  left: calc(-1 * var(--fa-li-width, 2em));
+  position: absolute;
+  text-align: center;
+  width: var(--fa-li-width, 2em);
+  line-height: inherit;
+}
+
+.fa-border {
+  border-color: var(--fa-border-color, #eee);
+  border-radius: var(--fa-border-radius, 0.1em);
+  border-style: var(--fa-border-style, solid);
+  border-width: var(--fa-border-width, 0.08em);
+  padding: var(--fa-border-padding, 0.2em 0.25em 0.15em);
+}
+
+.fa-pull-left {
+  float: left;
+  margin-right: var(--fa-pull-margin, 0.3em);
+}
+
+.fa-pull-right {
+  float: right;
+  margin-left: var(--fa-pull-margin, 0.3em);
+}
+
+.fa-beat {
+  animation-name: fa-beat;
+  animation-delay: var(--fa-animation-delay, 0s);
+  animation-direction: var(--fa-animation-direction, normal);
+  animation-duration: var(--fa-animation-duration, 1s);
+  animation-iteration-count: var(--fa-animation-iteration-count, infinite);
+  animation-timing-function: var(--fa-animation-timing, ease-in-out);
+}
+
+.fa-bounce {
+  animation-name: fa-bounce;
+  animation-delay: var(--fa-animation-delay, 0s);
+  animation-direction: var(--fa-animation-direction, normal);
+  animation-duration: var(--fa-animation-duration, 1s);
+  animation-iteration-count: var(--fa-animation-iteration-count, infinite);
+  animation-timing-function: var(--fa-animation-timing, cubic-bezier(0.28, 0.84, 0.42, 1));
+}
+
+.fa-fade {
+  animation-name: fa-fade;
+  animation-delay: var(--fa-animation-delay, 0s);
+  animation-direction: var(--fa-animation-direction, normal);
+  animation-duration: var(--fa-animation-duration, 1s);
+  animation-iteration-count: var(--fa-animation-iteration-count, infinite);
+  animation-timing-function: var(--fa-animation-timing, cubic-bezier(0.4, 0, 0.6, 1));
+}
+
+.fa-beat-fade {
+  animation-name: fa-beat-fade;
+  animation-delay: var(--fa-animation-delay, 0s);
+  animation-direction: var(--fa-animation-direction, normal);
+  animation-duration: var(--fa-animation-duration, 1s);
+  animation-iteration-count: var(--fa-animation-iteration-count, infinite);
+  animation-timing-function: var(--fa-animation-timing, cubic-bezier(0.4, 0, 0.6, 1));
+}
+
+.fa-flip {
+  animation-name: fa-flip;
+  animation-delay: var(--fa-animation-delay, 0s);
+  animation-direction: var(--fa-animation-direction, normal);
+  animation-duration: var(--fa-animation-duration, 1s);
+  animation-iteration-count: var(--fa-animation-iteration-count, infinite);
+  animation-timing-function: var(--fa-animation-timing, ease-in-out);
+}
+
+.fa-shake {
+  animation-name: fa-shake;
+  animation-delay: var(--fa-animation-delay, 0s);
+  animation-direction: var(--fa-animation-direction, normal);
+  animation-duration: var(--fa-animation-duration, 1s);
+  animation-iteration-count: var(--fa-animation-iteration-count, infinite);
+  animation-timing-function: var(--fa-animation-timing, linear);
+}
+
+.fa-spin {
+  animation-name: fa-spin;
+  animation-delay: var(--fa-animation-delay, 0s);
+  animation-direction: var(--fa-animation-direction, normal);
+  animation-duration: var(--fa-animation-duration, 2s);
+  animation-iteration-count: var(--fa-animation-iteration-count, infinite);
+  animation-timing-function: var(--fa-animation-timing, linear);
+}
+
+.fa-spin-reverse {
+  --fa-animation-direction: reverse;
+}
+
+.fa-pulse,
+.fa-spin-pulse {
+  animation-name: fa-spin;
+  animation-direction: var(--fa-animation-direction, normal);
+  animation-duration: var(--fa-animation-duration, 1s);
+  animation-iteration-count: var(--fa-animation-iteration-count, infinite);
+  animation-timing-function: var(--fa-animation-timing, steps(8));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fa-beat,
+  .fa-bounce,
+  .fa-fade,
+  .fa-beat-fade,
+  .fa-flip,
+  .fa-pulse,
+  .fa-shake,
+  .fa-spin,
+  .fa-spin-pulse {
+    animation-delay: -1ms;
+    animation-duration: 1ms;
+    animation-iteration-count: 1;
+    transition-delay: 0s;
+    transition-duration: 0s;
+  }
+}
+@keyframes fa-beat {
+  0%, 90% {
+    transform: scale(1);
+  }
+  45% {
+    transform: scale(var(--fa-beat-scale, 1.25));
+  }
+}
+@keyframes fa-bounce {
+  0% {
+    transform: scale(1, 1) translateY(0);
+  }
+  10% {
+    transform: scale(var(--fa-bounce-start-scale-x, 1.1), var(--fa-bounce-start-scale-y, 0.9)) translateY(0);
+  }
+  30% {
+    transform: scale(var(--fa-bounce-jump-scale-x, 0.9), var(--fa-bounce-jump-scale-y, 1.1)) translateY(var(--fa-bounce-height, -0.5em));
+  }
+  50% {
+    transform: scale(var(--fa-bounce-land-scale-x, 1.05), var(--fa-bounce-land-scale-y, 0.95)) translateY(0);
+  }
+  57% {
+    transform: scale(1, 1) translateY(var(--fa-bounce-rebound, -0.125em));
+  }
+  64% {
+    transform: scale(1, 1) translateY(0);
+  }
+  100% {
+    transform: scale(1, 1) translateY(0);
+  }
+}
+@keyframes fa-fade {
+  50% {
+    opacity: var(--fa-fade-opacity, 0.4);
+  }
+}
+@keyframes fa-beat-fade {
+  0%, 100% {
+    opacity: var(--fa-beat-fade-opacity, 0.4);
+    transform: scale(1);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(var(--fa-beat-fade-scale, 1.125));
+  }
+}
+@keyframes fa-flip {
+  50% {
+    transform: rotate3d(var(--fa-flip-x, 0), var(--fa-flip-y, 1), var(--fa-flip-z, 0), var(--fa-flip-angle, -180deg));
+  }
+}
+@keyframes fa-shake {
+  0% {
+    transform: rotate(-15deg);
+  }
+  4% {
+    transform: rotate(15deg);
+  }
+  8%, 24% {
+    transform: rotate(-18deg);
+  }
+  12%, 28% {
+    transform: rotate(18deg);
+  }
+  16% {
+    transform: rotate(-22deg);
+  }
+  20% {
+    transform: rotate(22deg);
+  }
+  32% {
+    transform: rotate(-12deg);
+  }
+  36% {
+    transform: rotate(12deg);
+  }
+  40%, 100% {
+    transform: rotate(0deg);
+  }
+}
+@keyframes fa-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+.fa-rotate-90 {
+  transform: rotate(90deg);
+}
+
+.fa-rotate-180 {
+  transform: rotate(180deg);
+}
+
+.fa-rotate-270 {
+  transform: rotate(270deg);
+}
+
+.fa-flip-horizontal {
+  transform: scale(-1, 1);
+}
+
+.fa-flip-vertical {
+  transform: scale(1, -1);
+}
+
+.fa-flip-both,
+.fa-flip-horizontal.fa-flip-vertical {
+  transform: scale(-1, -1);
+}
+
+.fa-rotate-by {
+  transform: rotate(var(--fa-rotate-angle, 0));
+}
+
+.fa-stack {
+  display: inline-block;
+  height: 2em;
+  line-height: 2em;
+  position: relative;
+  vertical-align: middle;
+  width: 2.5em;
+}
+
+.fa-stack-1x,
+.fa-stack-2x {
+  left: 0;
+  position: absolute;
+  text-align: center;
+  width: 100%;
+  z-index: var(--fa-stack-z-index, auto);
+}
+
+.fa-stack-1x {
+  line-height: inherit;
+}
+
+.fa-stack-2x {
+  font-size: 2em;
+}
+
+.fa-inverse {
+  color: var(--fa-inverse, #fff);
+}
+
+/* Font Awesome uses the Unicode Private Use Area (PUA) to ensure screen
+readers do not read off random characters that represent icons */
+.fa-0 {
+  --fa: "\30 ";
+}
+
+.fa-1 {
+  --fa: "\31 ";
+}
+
+.fa-2 {
+  --fa: "\32 ";
+}
+
+.fa-3 {
+  --fa: "\33 ";
+}
+
+.fa-4 {
+  --fa: "\34 ";
+}
+
+.fa-5 {
+  --fa: "\35 ";
+}
+
+.fa-6 {
+  --fa: "\36 ";
+}
+
+.fa-7 {
+  --fa: "\37 ";
+}
+
+.fa-8 {
+  --fa: "\38 ";
+}
+
+.fa-9 {
+  --fa: "\39 ";
+}
+
+.fa-fill-drip {
+  --fa: "\f576";
+}
+
+.fa-arrows-to-circle {
+  --fa: "\e4bd";
+}
+
+.fa-circle-chevron-right {
+  --fa: "\f138";
+}
+
+.fa-chevron-circle-right {
+  --fa: "\f138";
+}
+
+.fa-at {
+  --fa: "\@";
+}
+
+.fa-trash-can {
+  --fa: "\f2ed";
+}
+
+.fa-trash-alt {
+  --fa: "\f2ed";
+}
+
+.fa-text-height {
+  --fa: "\f034";
+}
+
+.fa-user-xmark {
+  --fa: "\f235";
+}
+
+.fa-user-times {
+  --fa: "\f235";
+}
+
+.fa-stethoscope {
+  --fa: "\f0f1";
+}
+
+.fa-message {
+  --fa: "\f27a";
+}
+
+.fa-comment-alt {
+  --fa: "\f27a";
+}
+
+.fa-info {
+  --fa: "\f129";
+}
+
+.fa-down-left-and-up-right-to-center {
+  --fa: "\f422";
+}
+
+.fa-compress-alt {
+  --fa: "\f422";
+}
+
+.fa-explosion {
+  --fa: "\e4e9";
+}
+
+.fa-file-lines {
+  --fa: "\f15c";
+}
+
+.fa-file-alt {
+  --fa: "\f15c";
+}
+
+.fa-file-text {
+  --fa: "\f15c";
+}
+
+.fa-wave-square {
+  --fa: "\f83e";
+}
+
+.fa-ring {
+  --fa: "\f70b";
+}
+
+.fa-building-un {
+  --fa: "\e4d9";
+}
+
+.fa-dice-three {
+  --fa: "\f527";
+}
+
+.fa-calendar-days {
+  --fa: "\f073";
+}
+
+.fa-calendar-alt {
+  --fa: "\f073";
+}
+
+.fa-anchor-circle-check {
+  --fa: "\e4aa";
+}
+
+.fa-building-circle-arrow-right {
+  --fa: "\e4d1";
+}
+
+.fa-volleyball {
+  --fa: "\f45f";
+}
+
+.fa-volleyball-ball {
+  --fa: "\f45f";
+}
+
+.fa-arrows-up-to-line {
+  --fa: "\e4c2";
+}
+
+.fa-sort-down {
+  --fa: "\f0dd";
+}
+
+.fa-sort-desc {
+  --fa: "\f0dd";
+}
+
+.fa-circle-minus {
+  --fa: "\f056";
+}
+
+.fa-minus-circle {
+  --fa: "\f056";
+}
+
+.fa-door-open {
+  --fa: "\f52b";
+}
+
+.fa-right-from-bracket {
+  --fa: "\f2f5";
+}
+
+.fa-sign-out-alt {
+  --fa: "\f2f5";
+}
+
+.fa-atom {
+  --fa: "\f5d2";
+}
+
+.fa-soap {
+  --fa: "\e06e";
+}
+
+.fa-icons {
+  --fa: "\f86d";
+}
+
+.fa-heart-music-camera-bolt {
+  --fa: "\f86d";
+}
+
+.fa-microphone-lines-slash {
+  --fa: "\f539";
+}
+
+.fa-microphone-alt-slash {
+  --fa: "\f539";
+}
+
+.fa-bridge-circle-check {
+  --fa: "\e4c9";
+}
+
+.fa-pump-medical {
+  --fa: "\e06a";
+}
+
+.fa-fingerprint {
+  --fa: "\f577";
+}
+
+.fa-hand-point-right {
+  --fa: "\f0a4";
+}
+
+.fa-magnifying-glass-location {
+  --fa: "\f689";
+}
+
+.fa-search-location {
+  --fa: "\f689";
+}
+
+.fa-forward-step {
+  --fa: "\f051";
+}
+
+.fa-step-forward {
+  --fa: "\f051";
+}
+
+.fa-face-smile-beam {
+  --fa: "\f5b8";
+}
+
+.fa-smile-beam {
+  --fa: "\f5b8";
+}
+
+.fa-flag-checkered {
+  --fa: "\f11e";
+}
+
+.fa-football {
+  --fa: "\f44e";
+}
+
+.fa-football-ball {
+  --fa: "\f44e";
+}
+
+.fa-school-circle-exclamation {
+  --fa: "\e56c";
+}
+
+.fa-crop {
+  --fa: "\f125";
+}
+
+.fa-angles-down {
+  --fa: "\f103";
+}
+
+.fa-angle-double-down {
+  --fa: "\f103";
+}
+
+.fa-users-rectangle {
+  --fa: "\e594";
+}
+
+.fa-people-roof {
+  --fa: "\e537";
+}
+
+.fa-people-line {
+  --fa: "\e534";
+}
+
+.fa-beer-mug-empty {
+  --fa: "\f0fc";
+}
+
+.fa-beer {
+  --fa: "\f0fc";
+}
+
+.fa-diagram-predecessor {
+  --fa: "\e477";
+}
+
+.fa-arrow-up-long {
+  --fa: "\f176";
+}
+
+.fa-long-arrow-up {
+  --fa: "\f176";
+}
+
+.fa-fire-flame-simple {
+  --fa: "\f46a";
+}
+
+.fa-burn {
+  --fa: "\f46a";
+}
+
+.fa-person {
+  --fa: "\f183";
+}
+
+.fa-male {
+  --fa: "\f183";
+}
+
+.fa-laptop {
+  --fa: "\f109";
+}
+
+.fa-file-csv {
+  --fa: "\f6dd";
+}
+
+.fa-menorah {
+  --fa: "\f676";
+}
+
+.fa-truck-plane {
+  --fa: "\e58f";
+}
+
+.fa-record-vinyl {
+  --fa: "\f8d9";
+}
+
+.fa-face-grin-stars {
+  --fa: "\f587";
+}
+
+.fa-grin-stars {
+  --fa: "\f587";
+}
+
+.fa-bong {
+  --fa: "\f55c";
+}
+
+.fa-spaghetti-monster-flying {
+  --fa: "\f67b";
+}
+
+.fa-pastafarianism {
+  --fa: "\f67b";
+}
+
+.fa-arrow-down-up-across-line {
+  --fa: "\e4af";
+}
+
+.fa-spoon {
+  --fa: "\f2e5";
+}
+
+.fa-utensil-spoon {
+  --fa: "\f2e5";
+}
+
+.fa-jar-wheat {
+  --fa: "\e517";
+}
+
+.fa-envelopes-bulk {
+  --fa: "\f674";
+}
+
+.fa-mail-bulk {
+  --fa: "\f674";
+}
+
+.fa-file-circle-exclamation {
+  --fa: "\e4eb";
+}
+
+.fa-circle-h {
+  --fa: "\f47e";
+}
+
+.fa-hospital-symbol {
+  --fa: "\f47e";
+}
+
+.fa-pager {
+  --fa: "\f815";
+}
+
+.fa-address-book {
+  --fa: "\f2b9";
+}
+
+.fa-contact-book {
+  --fa: "\f2b9";
+}
+
+.fa-strikethrough {
+  --fa: "\f0cc";
+}
+
+.fa-k {
+  --fa: "K";
+}
+
+.fa-landmark-flag {
+  --fa: "\e51c";
+}
+
+.fa-pencil {
+  --fa: "\f303";
+}
+
+.fa-pencil-alt {
+  --fa: "\f303";
+}
+
+.fa-backward {
+  --fa: "\f04a";
+}
+
+.fa-caret-right {
+  --fa: "\f0da";
+}
+
+.fa-comments {
+  --fa: "\f086";
+}
+
+.fa-paste {
+  --fa: "\f0ea";
+}
+
+.fa-file-clipboard {
+  --fa: "\f0ea";
+}
+
+.fa-code-pull-request {
+  --fa: "\e13c";
+}
+
+.fa-clipboard-list {
+  --fa: "\f46d";
+}
+
+.fa-truck-ramp-box {
+  --fa: "\f4de";
+}
+
+.fa-truck-loading {
+  --fa: "\f4de";
+}
+
+.fa-user-check {
+  --fa: "\f4fc";
+}
+
+.fa-vial-virus {
+  --fa: "\e597";
+}
+
+.fa-sheet-plastic {
+  --fa: "\e571";
+}
+
+.fa-blog {
+  --fa: "\f781";
+}
+
+.fa-user-ninja {
+  --fa: "\f504";
+}
+
+.fa-person-arrow-up-from-line {
+  --fa: "\e539";
+}
+
+.fa-scroll-torah {
+  --fa: "\f6a0";
+}
+
+.fa-torah {
+  --fa: "\f6a0";
+}
+
+.fa-broom-ball {
+  --fa: "\f458";
+}
+
+.fa-quidditch {
+  --fa: "\f458";
+}
+
+.fa-quidditch-broom-ball {
+  --fa: "\f458";
+}
+
+.fa-toggle-off {
+  --fa: "\f204";
+}
+
+.fa-box-archive {
+  --fa: "\f187";
+}
+
+.fa-archive {
+  --fa: "\f187";
+}
+
+.fa-person-drowning {
+  --fa: "\e545";
+}
+
+.fa-arrow-down-9-1 {
+  --fa: "\f886";
+}
+
+.fa-sort-numeric-desc {
+  --fa: "\f886";
+}
+
+.fa-sort-numeric-down-alt {
+  --fa: "\f886";
+}
+
+.fa-face-grin-tongue-squint {
+  --fa: "\f58a";
+}
+
+.fa-grin-tongue-squint {
+  --fa: "\f58a";
+}
+
+.fa-spray-can {
+  --fa: "\f5bd";
+}
+
+.fa-truck-monster {
+  --fa: "\f63b";
+}
+
+.fa-w {
+  --fa: "W";
+}
+
+.fa-earth-africa {
+  --fa: "\f57c";
+}
+
+.fa-globe-africa {
+  --fa: "\f57c";
+}
+
+.fa-rainbow {
+  --fa: "\f75b";
+}
+
+.fa-circle-notch {
+  --fa: "\f1ce";
+}
+
+.fa-tablet-screen-button {
+  --fa: "\f3fa";
+}
+
+.fa-tablet-alt {
+  --fa: "\f3fa";
+}
+
+.fa-paw {
+  --fa: "\f1b0";
+}
+
+.fa-cloud {
+  --fa: "\f0c2";
+}
+
+.fa-trowel-bricks {
+  --fa: "\e58a";
+}
+
+.fa-face-flushed {
+  --fa: "\f579";
+}
+
+.fa-flushed {
+  --fa: "\f579";
+}
+
+.fa-hospital-user {
+  --fa: "\f80d";
+}
+
+.fa-tent-arrow-left-right {
+  --fa: "\e57f";
+}
+
+.fa-gavel {
+  --fa: "\f0e3";
+}
+
+.fa-legal {
+  --fa: "\f0e3";
+}
+
+.fa-binoculars {
+  --fa: "\f1e5";
+}
+
+.fa-microphone-slash {
+  --fa: "\f131";
+}
+
+.fa-box-tissue {
+  --fa: "\e05b";
+}
+
+.fa-motorcycle {
+  --fa: "\f21c";
+}
+
+.fa-bell-concierge {
+  --fa: "\f562";
+}
+
+.fa-concierge-bell {
+  --fa: "\f562";
+}
+
+.fa-pen-ruler {
+  --fa: "\f5ae";
+}
+
+.fa-pencil-ruler {
+  --fa: "\f5ae";
+}
+
+.fa-people-arrows {
+  --fa: "\e068";
+}
+
+.fa-people-arrows-left-right {
+  --fa: "\e068";
+}
+
+.fa-mars-and-venus-burst {
+  --fa: "\e523";
+}
+
+.fa-square-caret-right {
+  --fa: "\f152";
+}
+
+.fa-caret-square-right {
+  --fa: "\f152";
+}
+
+.fa-scissors {
+  --fa: "\f0c4";
+}
+
+.fa-cut {
+  --fa: "\f0c4";
+}
+
+.fa-sun-plant-wilt {
+  --fa: "\e57a";
+}
+
+.fa-toilets-portable {
+  --fa: "\e584";
+}
+
+.fa-hockey-puck {
+  --fa: "\f453";
+}
+
+.fa-table {
+  --fa: "\f0ce";
+}
+
+.fa-magnifying-glass-arrow-right {
+  --fa: "\e521";
+}
+
+.fa-tachograph-digital {
+  --fa: "\f566";
+}
+
+.fa-digital-tachograph {
+  --fa: "\f566";
+}
+
+.fa-users-slash {
+  --fa: "\e073";
+}
+
+.fa-clover {
+  --fa: "\e139";
+}
+
+.fa-reply {
+  --fa: "\f3e5";
+}
+
+.fa-mail-reply {
+  --fa: "\f3e5";
+}
+
+.fa-star-and-crescent {
+  --fa: "\f699";
+}
+
+.fa-house-fire {
+  --fa: "\e50c";
+}
+
+.fa-square-minus {
+  --fa: "\f146";
+}
+
+.fa-minus-square {
+  --fa: "\f146";
+}
+
+.fa-helicopter {
+  --fa: "\f533";
+}
+
+.fa-compass {
+  --fa: "\f14e";
+}
+
+.fa-square-caret-down {
+  --fa: "\f150";
+}
+
+.fa-caret-square-down {
+  --fa: "\f150";
+}
+
+.fa-file-circle-question {
+  --fa: "\e4ef";
+}
+
+.fa-laptop-code {
+  --fa: "\f5fc";
+}
+
+.fa-swatchbook {
+  --fa: "\f5c3";
+}
+
+.fa-prescription-bottle {
+  --fa: "\f485";
+}
+
+.fa-bars {
+  --fa: "\f0c9";
+}
+
+.fa-navicon {
+  --fa: "\f0c9";
+}
+
+.fa-people-group {
+  --fa: "\e533";
+}
+
+.fa-hourglass-end {
+  --fa: "\f253";
+}
+
+.fa-hourglass-3 {
+  --fa: "\f253";
+}
+
+.fa-heart-crack {
+  --fa: "\f7a9";
+}
+
+.fa-heart-broken {
+  --fa: "\f7a9";
+}
+
+.fa-square-up-right {
+  --fa: "\f360";
+}
+
+.fa-external-link-square-alt {
+  --fa: "\f360";
+}
+
+.fa-face-kiss-beam {
+  --fa: "\f597";
+}
+
+.fa-kiss-beam {
+  --fa: "\f597";
+}
+
+.fa-film {
+  --fa: "\f008";
+}
+
+.fa-ruler-horizontal {
+  --fa: "\f547";
+}
+
+.fa-people-robbery {
+  --fa: "\e536";
+}
+
+.fa-lightbulb {
+  --fa: "\f0eb";
+}
+
+.fa-caret-left {
+  --fa: "\f0d9";
+}
+
+.fa-circle-exclamation {
+  --fa: "\f06a";
+}
+
+.fa-exclamation-circle {
+  --fa: "\f06a";
+}
+
+.fa-school-circle-xmark {
+  --fa: "\e56d";
+}
+
+.fa-arrow-right-from-bracket {
+  --fa: "\f08b";
+}
+
+.fa-sign-out {
+  --fa: "\f08b";
+}
+
+.fa-circle-chevron-down {
+  --fa: "\f13a";
+}
+
+.fa-chevron-circle-down {
+  --fa: "\f13a";
+}
+
+.fa-unlock-keyhole {
+  --fa: "\f13e";
+}
+
+.fa-unlock-alt {
+  --fa: "\f13e";
+}
+
+.fa-cloud-showers-heavy {
+  --fa: "\f740";
+}
+
+.fa-headphones-simple {
+  --fa: "\f58f";
+}
+
+.fa-headphones-alt {
+  --fa: "\f58f";
+}
+
+.fa-sitemap {
+  --fa: "\f0e8";
+}
+
+.fa-circle-dollar-to-slot {
+  --fa: "\f4b9";
+}
+
+.fa-donate {
+  --fa: "\f4b9";
+}
+
+.fa-memory {
+  --fa: "\f538";
+}
+
+.fa-road-spikes {
+  --fa: "\e568";
+}
+
+.fa-fire-burner {
+  --fa: "\e4f1";
+}
+
+.fa-flag {
+  --fa: "\f024";
+}
+
+.fa-hanukiah {
+  --fa: "\f6e6";
+}
+
+.fa-feather {
+  --fa: "\f52d";
+}
+
+.fa-volume-low {
+  --fa: "\f027";
+}
+
+.fa-volume-down {
+  --fa: "\f027";
+}
+
+.fa-comment-slash {
+  --fa: "\f4b3";
+}
+
+.fa-cloud-sun-rain {
+  --fa: "\f743";
+}
+
+.fa-compress {
+  --fa: "\f066";
+}
+
+.fa-wheat-awn {
+  --fa: "\e2cd";
+}
+
+.fa-wheat-alt {
+  --fa: "\e2cd";
+}
+
+.fa-ankh {
+  --fa: "\f644";
+}
+
+.fa-hands-holding-child {
+  --fa: "\e4fa";
+}
+
+.fa-asterisk {
+  --fa: "\*";
+}
+
+.fa-square-check {
+  --fa: "\f14a";
+}
+
+.fa-check-square {
+  --fa: "\f14a";
+}
+
+.fa-peseta-sign {
+  --fa: "\e221";
+}
+
+.fa-heading {
+  --fa: "\f1dc";
+}
+
+.fa-header {
+  --fa: "\f1dc";
+}
+
+.fa-ghost {
+  --fa: "\f6e2";
+}
+
+.fa-list {
+  --fa: "\f03a";
+}
+
+.fa-list-squares {
+  --fa: "\f03a";
+}
+
+.fa-square-phone-flip {
+  --fa: "\f87b";
+}
+
+.fa-phone-square-alt {
+  --fa: "\f87b";
+}
+
+.fa-cart-plus {
+  --fa: "\f217";
+}
+
+.fa-gamepad {
+  --fa: "\f11b";
+}
+
+.fa-circle-dot {
+  --fa: "\f192";
+}
+
+.fa-dot-circle {
+  --fa: "\f192";
+}
+
+.fa-face-dizzy {
+  --fa: "\f567";
+}
+
+.fa-dizzy {
+  --fa: "\f567";
+}
+
+.fa-egg {
+  --fa: "\f7fb";
+}
+
+.fa-house-medical-circle-xmark {
+  --fa: "\e513";
+}
+
+.fa-campground {
+  --fa: "\f6bb";
+}
+
+.fa-folder-plus {
+  --fa: "\f65e";
+}
+
+.fa-futbol {
+  --fa: "\f1e3";
+}
+
+.fa-futbol-ball {
+  --fa: "\f1e3";
+}
+
+.fa-soccer-ball {
+  --fa: "\f1e3";
+}
+
+.fa-paintbrush {
+  --fa: "\f1fc";
+}
+
+.fa-paint-brush {
+  --fa: "\f1fc";
+}
+
+.fa-lock {
+  --fa: "\f023";
+}
+
+.fa-gas-pump {
+  --fa: "\f52f";
+}
+
+.fa-hot-tub-person {
+  --fa: "\f593";
+}
+
+.fa-hot-tub {
+  --fa: "\f593";
+}
+
+.fa-map-location {
+  --fa: "\f59f";
+}
+
+.fa-map-marked {
+  --fa: "\f59f";
+}
+
+.fa-house-flood-water {
+  --fa: "\e50e";
+}
+
+.fa-tree {
+  --fa: "\f1bb";
+}
+
+.fa-bridge-lock {
+  --fa: "\e4cc";
+}
+
+.fa-sack-dollar {
+  --fa: "\f81d";
+}
+
+.fa-pen-to-square {
+  --fa: "\f044";
+}
+
+.fa-edit {
+  --fa: "\f044";
+}
+
+.fa-car-side {
+  --fa: "\f5e4";
+}
+
+.fa-share-nodes {
+  --fa: "\f1e0";
+}
+
+.fa-share-alt {
+  --fa: "\f1e0";
+}
+
+.fa-heart-circle-minus {
+  --fa: "\e4ff";
+}
+
+.fa-hourglass-half {
+  --fa: "\f252";
+}
+
+.fa-hourglass-2 {
+  --fa: "\f252";
+}
+
+.fa-microscope {
+  --fa: "\f610";
+}
+
+.fa-sink {
+  --fa: "\e06d";
+}
+
+.fa-bag-shopping {
+  --fa: "\f290";
+}
+
+.fa-shopping-bag {
+  --fa: "\f290";
+}
+
+.fa-arrow-down-z-a {
+  --fa: "\f881";
+}
+
+.fa-sort-alpha-desc {
+  --fa: "\f881";
+}
+
+.fa-sort-alpha-down-alt {
+  --fa: "\f881";
+}
+
+.fa-mitten {
+  --fa: "\f7b5";
+}
+
+.fa-person-rays {
+  --fa: "\e54d";
+}
+
+.fa-users {
+  --fa: "\f0c0";
+}
+
+.fa-eye-slash {
+  --fa: "\f070";
+}
+
+.fa-flask-vial {
+  --fa: "\e4f3";
+}
+
+.fa-hand {
+  --fa: "\f256";
+}
+
+.fa-hand-paper {
+  --fa: "\f256";
+}
+
+.fa-om {
+  --fa: "\f679";
+}
+
+.fa-worm {
+  --fa: "\e599";
+}
+
+.fa-house-circle-xmark {
+  --fa: "\e50b";
+}
+
+.fa-plug {
+  --fa: "\f1e6";
+}
+
+.fa-chevron-up {
+  --fa: "\f077";
+}
+
+.fa-hand-spock {
+  --fa: "\f259";
+}
+
+.fa-stopwatch {
+  --fa: "\f2f2";
+}
+
+.fa-face-kiss {
+  --fa: "\f596";
+}
+
+.fa-kiss {
+  --fa: "\f596";
+}
+
+.fa-bridge-circle-xmark {
+  --fa: "\e4cb";
+}
+
+.fa-face-grin-tongue {
+  --fa: "\f589";
+}
+
+.fa-grin-tongue {
+  --fa: "\f589";
+}
+
+.fa-chess-bishop {
+  --fa: "\f43a";
+}
+
+.fa-face-grin-wink {
+  --fa: "\f58c";
+}
+
+.fa-grin-wink {
+  --fa: "\f58c";
+}
+
+.fa-ear-deaf {
+  --fa: "\f2a4";
+}
+
+.fa-deaf {
+  --fa: "\f2a4";
+}
+
+.fa-deafness {
+  --fa: "\f2a4";
+}
+
+.fa-hard-of-hearing {
+  --fa: "\f2a4";
+}
+
+.fa-road-circle-check {
+  --fa: "\e564";
+}
+
+.fa-dice-five {
+  --fa: "\f523";
+}
+
+.fa-square-rss {
+  --fa: "\f143";
+}
+
+.fa-rss-square {
+  --fa: "\f143";
+}
+
+.fa-land-mine-on {
+  --fa: "\e51b";
+}
+
+.fa-i-cursor {
+  --fa: "\f246";
+}
+
+.fa-stamp {
+  --fa: "\f5bf";
+}
+
+.fa-stairs {
+  --fa: "\e289";
+}
+
+.fa-i {
+  --fa: "I";
+}
+
+.fa-hryvnia-sign {
+  --fa: "\f6f2";
+}
+
+.fa-hryvnia {
+  --fa: "\f6f2";
+}
+
+.fa-pills {
+  --fa: "\f484";
+}
+
+.fa-face-grin-wide {
+  --fa: "\f581";
+}
+
+.fa-grin-alt {
+  --fa: "\f581";
+}
+
+.fa-tooth {
+  --fa: "\f5c9";
+}
+
+.fa-v {
+  --fa: "V";
+}
+
+.fa-bangladeshi-taka-sign {
+  --fa: "\e2e6";
+}
+
+.fa-bicycle {
+  --fa: "\f206";
+}
+
+.fa-staff-snake {
+  --fa: "\e579";
+}
+
+.fa-rod-asclepius {
+  --fa: "\e579";
+}
+
+.fa-rod-snake {
+  --fa: "\e579";
+}
+
+.fa-staff-aesculapius {
+  --fa: "\e579";
+}
+
+.fa-head-side-cough-slash {
+  --fa: "\e062";
+}
+
+.fa-truck-medical {
+  --fa: "\f0f9";
+}
+
+.fa-ambulance {
+  --fa: "\f0f9";
+}
+
+.fa-wheat-awn-circle-exclamation {
+  --fa: "\e598";
+}
+
+.fa-snowman {
+  --fa: "\f7d0";
+}
+
+.fa-mortar-pestle {
+  --fa: "\f5a7";
+}
+
+.fa-road-barrier {
+  --fa: "\e562";
+}
+
+.fa-school {
+  --fa: "\f549";
+}
+
+.fa-igloo {
+  --fa: "\f7ae";
+}
+
+.fa-joint {
+  --fa: "\f595";
+}
+
+.fa-angle-right {
+  --fa: "\f105";
+}
+
+.fa-horse {
+  --fa: "\f6f0";
+}
+
+.fa-q {
+  --fa: "Q";
+}
+
+.fa-g {
+  --fa: "G";
+}
+
+.fa-notes-medical {
+  --fa: "\f481";
+}
+
+.fa-temperature-half {
+  --fa: "\f2c9";
+}
+
+.fa-temperature-2 {
+  --fa: "\f2c9";
+}
+
+.fa-thermometer-2 {
+  --fa: "\f2c9";
+}
+
+.fa-thermometer-half {
+  --fa: "\f2c9";
+}
+
+.fa-dong-sign {
+  --fa: "\e169";
+}
+
+.fa-capsules {
+  --fa: "\f46b";
+}
+
+.fa-poo-storm {
+  --fa: "\f75a";
+}
+
+.fa-poo-bolt {
+  --fa: "\f75a";
+}
+
+.fa-face-frown-open {
+  --fa: "\f57a";
+}
+
+.fa-frown-open {
+  --fa: "\f57a";
+}
+
+.fa-hand-point-up {
+  --fa: "\f0a6";
+}
+
+.fa-money-bill {
+  --fa: "\f0d6";
+}
+
+.fa-bookmark {
+  --fa: "\f02e";
+}
+
+.fa-align-justify {
+  --fa: "\f039";
+}
+
+.fa-umbrella-beach {
+  --fa: "\f5ca";
+}
+
+.fa-helmet-un {
+  --fa: "\e503";
+}
+
+.fa-bullseye {
+  --fa: "\f140";
+}
+
+.fa-bacon {
+  --fa: "\f7e5";
+}
+
+.fa-hand-point-down {
+  --fa: "\f0a7";
+}
+
+.fa-arrow-up-from-bracket {
+  --fa: "\e09a";
+}
+
+.fa-folder {
+  --fa: "\f07b";
+}
+
+.fa-folder-blank {
+  --fa: "\f07b";
+}
+
+.fa-file-waveform {
+  --fa: "\f478";
+}
+
+.fa-file-medical-alt {
+  --fa: "\f478";
+}
+
+.fa-radiation {
+  --fa: "\f7b9";
+}
+
+.fa-chart-simple {
+  --fa: "\e473";
+}
+
+.fa-mars-stroke {
+  --fa: "\f229";
+}
+
+.fa-vial {
+  --fa: "\f492";
+}
+
+.fa-gauge {
+  --fa: "\f624";
+}
+
+.fa-dashboard {
+  --fa: "\f624";
+}
+
+.fa-gauge-med {
+  --fa: "\f624";
+}
+
+.fa-tachometer-alt-average {
+  --fa: "\f624";
+}
+
+.fa-wand-magic-sparkles {
+  --fa: "\e2ca";
+}
+
+.fa-magic-wand-sparkles {
+  --fa: "\e2ca";
+}
+
+.fa-e {
+  --fa: "E";
+}
+
+.fa-pen-clip {
+  --fa: "\f305";
+}
+
+.fa-pen-alt {
+  --fa: "\f305";
+}
+
+.fa-bridge-circle-exclamation {
+  --fa: "\e4ca";
+}
+
+.fa-user {
+  --fa: "\f007";
+}
+
+.fa-school-circle-check {
+  --fa: "\e56b";
+}
+
+.fa-dumpster {
+  --fa: "\f793";
+}
+
+.fa-van-shuttle {
+  --fa: "\f5b6";
+}
+
+.fa-shuttle-van {
+  --fa: "\f5b6";
+}
+
+.fa-building-user {
+  --fa: "\e4da";
+}
+
+.fa-square-caret-left {
+  --fa: "\f191";
+}
+
+.fa-caret-square-left {
+  --fa: "\f191";
+}
+
+.fa-highlighter {
+  --fa: "\f591";
+}
+
+.fa-key {
+  --fa: "\f084";
+}
+
+.fa-bullhorn {
+  --fa: "\f0a1";
+}
+
+.fa-globe {
+  --fa: "\f0ac";
+}
+
+.fa-synagogue {
+  --fa: "\f69b";
+}
+
+.fa-person-half-dress {
+  --fa: "\e548";
+}
+
+.fa-road-bridge {
+  --fa: "\e563";
+}
+
+.fa-location-arrow {
+  --fa: "\f124";
+}
+
+.fa-c {
+  --fa: "C";
+}
+
+.fa-tablet-button {
+  --fa: "\f10a";
+}
+
+.fa-building-lock {
+  --fa: "\e4d6";
+}
+
+.fa-pizza-slice {
+  --fa: "\f818";
+}
+
+.fa-money-bill-wave {
+  --fa: "\f53a";
+}
+
+.fa-chart-area {
+  --fa: "\f1fe";
+}
+
+.fa-area-chart {
+  --fa: "\f1fe";
+}
+
+.fa-house-flag {
+  --fa: "\e50d";
+}
+
+.fa-person-circle-minus {
+  --fa: "\e540";
+}
+
+.fa-ban {
+  --fa: "\f05e";
+}
+
+.fa-cancel {
+  --fa: "\f05e";
+}
+
+.fa-camera-rotate {
+  --fa: "\e0d8";
+}
+
+.fa-spray-can-sparkles {
+  --fa: "\f5d0";
+}
+
+.fa-air-freshener {
+  --fa: "\f5d0";
+}
+
+.fa-star {
+  --fa: "\f005";
+}
+
+.fa-repeat {
+  --fa: "\f363";
+}
+
+.fa-cross {
+  --fa: "\f654";
+}
+
+.fa-box {
+  --fa: "\f466";
+}
+
+.fa-venus-mars {
+  --fa: "\f228";
+}
+
+.fa-arrow-pointer {
+  --fa: "\f245";
+}
+
+.fa-mouse-pointer {
+  --fa: "\f245";
+}
+
+.fa-maximize {
+  --fa: "\f31e";
+}
+
+.fa-expand-arrows-alt {
+  --fa: "\f31e";
+}
+
+.fa-charging-station {
+  --fa: "\f5e7";
+}
+
+.fa-shapes {
+  --fa: "\f61f";
+}
+
+.fa-triangle-circle-square {
+  --fa: "\f61f";
+}
+
+.fa-shuffle {
+  --fa: "\f074";
+}
+
+.fa-random {
+  --fa: "\f074";
+}
+
+.fa-person-running {
+  --fa: "\f70c";
+}
+
+.fa-running {
+  --fa: "\f70c";
+}
+
+.fa-mobile-retro {
+  --fa: "\e527";
+}
+
+.fa-grip-lines-vertical {
+  --fa: "\f7a5";
+}
+
+.fa-spider {
+  --fa: "\f717";
+}
+
+.fa-hands-bound {
+  --fa: "\e4f9";
+}
+
+.fa-file-invoice-dollar {
+  --fa: "\f571";
+}
+
+.fa-plane-circle-exclamation {
+  --fa: "\e556";
+}
+
+.fa-x-ray {
+  --fa: "\f497";
+}
+
+.fa-spell-check {
+  --fa: "\f891";
+}
+
+.fa-slash {
+  --fa: "\f715";
+}
+
+.fa-computer-mouse {
+  --fa: "\f8cc";
+}
+
+.fa-mouse {
+  --fa: "\f8cc";
+}
+
+.fa-arrow-right-to-bracket {
+  --fa: "\f090";
+}
+
+.fa-sign-in {
+  --fa: "\f090";
+}
+
+.fa-shop-slash {
+  --fa: "\e070";
+}
+
+.fa-store-alt-slash {
+  --fa: "\e070";
+}
+
+.fa-server {
+  --fa: "\f233";
+}
+
+.fa-virus-covid-slash {
+  --fa: "\e4a9";
+}
+
+.fa-shop-lock {
+  --fa: "\e4a5";
+}
+
+.fa-hourglass-start {
+  --fa: "\f251";
+}
+
+.fa-hourglass-1 {
+  --fa: "\f251";
+}
+
+.fa-blender-phone {
+  --fa: "\f6b6";
+}
+
+.fa-building-wheat {
+  --fa: "\e4db";
+}
+
+.fa-person-breastfeeding {
+  --fa: "\e53a";
+}
+
+.fa-right-to-bracket {
+  --fa: "\f2f6";
+}
+
+.fa-sign-in-alt {
+  --fa: "\f2f6";
+}
+
+.fa-venus {
+  --fa: "\f221";
+}
+
+.fa-passport {
+  --fa: "\f5ab";
+}
+
+.fa-thumbtack-slash {
+  --fa: "\e68f";
+}
+
+.fa-thumb-tack-slash {
+  --fa: "\e68f";
+}
+
+.fa-heart-pulse {
+  --fa: "\f21e";
+}
+
+.fa-heartbeat {
+  --fa: "\f21e";
+}
+
+.fa-people-carry-box {
+  --fa: "\f4ce";
+}
+
+.fa-people-carry {
+  --fa: "\f4ce";
+}
+
+.fa-temperature-high {
+  --fa: "\f769";
+}
+
+.fa-microchip {
+  --fa: "\f2db";
+}
+
+.fa-crown {
+  --fa: "\f521";
+}
+
+.fa-weight-hanging {
+  --fa: "\f5cd";
+}
+
+.fa-xmarks-lines {
+  --fa: "\e59a";
+}
+
+.fa-file-prescription {
+  --fa: "\f572";
+}
+
+.fa-weight-scale {
+  --fa: "\f496";
+}
+
+.fa-weight {
+  --fa: "\f496";
+}
+
+.fa-user-group {
+  --fa: "\f500";
+}
+
+.fa-user-friends {
+  --fa: "\f500";
+}
+
+.fa-arrow-up-a-z {
+  --fa: "\f15e";
+}
+
+.fa-sort-alpha-up {
+  --fa: "\f15e";
+}
+
+.fa-chess-knight {
+  --fa: "\f441";
+}
+
+.fa-face-laugh-squint {
+  --fa: "\f59b";
+}
+
+.fa-laugh-squint {
+  --fa: "\f59b";
+}
+
+.fa-wheelchair {
+  --fa: "\f193";
+}
+
+.fa-circle-arrow-up {
+  --fa: "\f0aa";
+}
+
+.fa-arrow-circle-up {
+  --fa: "\f0aa";
+}
+
+.fa-toggle-on {
+  --fa: "\f205";
+}
+
+.fa-person-walking {
+  --fa: "\f554";
+}
+
+.fa-walking {
+  --fa: "\f554";
+}
+
+.fa-l {
+  --fa: "L";
+}
+
+.fa-fire {
+  --fa: "\f06d";
+}
+
+.fa-bed-pulse {
+  --fa: "\f487";
+}
+
+.fa-procedures {
+  --fa: "\f487";
+}
+
+.fa-shuttle-space {
+  --fa: "\f197";
+}
+
+.fa-space-shuttle {
+  --fa: "\f197";
+}
+
+.fa-face-laugh {
+  --fa: "\f599";
+}
+
+.fa-laugh {
+  --fa: "\f599";
+}
+
+.fa-folder-open {
+  --fa: "\f07c";
+}
+
+.fa-heart-circle-plus {
+  --fa: "\e500";
+}
+
+.fa-code-fork {
+  --fa: "\e13b";
+}
+
+.fa-city {
+  --fa: "\f64f";
+}
+
+.fa-microphone-lines {
+  --fa: "\f3c9";
+}
+
+.fa-microphone-alt {
+  --fa: "\f3c9";
+}
+
+.fa-pepper-hot {
+  --fa: "\f816";
+}
+
+.fa-unlock {
+  --fa: "\f09c";
+}
+
+.fa-colon-sign {
+  --fa: "\e140";
+}
+
+.fa-headset {
+  --fa: "\f590";
+}
+
+.fa-store-slash {
+  --fa: "\e071";
+}
+
+.fa-road-circle-xmark {
+  --fa: "\e566";
+}
+
+.fa-user-minus {
+  --fa: "\f503";
+}
+
+.fa-mars-stroke-up {
+  --fa: "\f22a";
+}
+
+.fa-mars-stroke-v {
+  --fa: "\f22a";
+}
+
+.fa-champagne-glasses {
+  --fa: "\f79f";
+}
+
+.fa-glass-cheers {
+  --fa: "\f79f";
+}
+
+.fa-clipboard {
+  --fa: "\f328";
+}
+
+.fa-house-circle-exclamation {
+  --fa: "\e50a";
+}
+
+.fa-file-arrow-up {
+  --fa: "\f574";
+}
+
+.fa-file-upload {
+  --fa: "\f574";
+}
+
+.fa-wifi {
+  --fa: "\f1eb";
+}
+
+.fa-wifi-3 {
+  --fa: "\f1eb";
+}
+
+.fa-wifi-strong {
+  --fa: "\f1eb";
+}
+
+.fa-bath {
+  --fa: "\f2cd";
+}
+
+.fa-bathtub {
+  --fa: "\f2cd";
+}
+
+.fa-underline {
+  --fa: "\f0cd";
+}
+
+.fa-user-pen {
+  --fa: "\f4ff";
+}
+
+.fa-user-edit {
+  --fa: "\f4ff";
+}
+
+.fa-signature {
+  --fa: "\f5b7";
+}
+
+.fa-stroopwafel {
+  --fa: "\f551";
+}
+
+.fa-bold {
+  --fa: "\f032";
+}
+
+.fa-anchor-lock {
+  --fa: "\e4ad";
+}
+
+.fa-building-ngo {
+  --fa: "\e4d7";
+}
+
+.fa-manat-sign {
+  --fa: "\e1d5";
+}
+
+.fa-not-equal {
+  --fa: "\f53e";
+}
+
+.fa-border-top-left {
+  --fa: "\f853";
+}
+
+.fa-border-style {
+  --fa: "\f853";
+}
+
+.fa-map-location-dot {
+  --fa: "\f5a0";
+}
+
+.fa-map-marked-alt {
+  --fa: "\f5a0";
+}
+
+.fa-jedi {
+  --fa: "\f669";
+}
+
+.fa-square-poll-vertical {
+  --fa: "\f681";
+}
+
+.fa-poll {
+  --fa: "\f681";
+}
+
+.fa-mug-hot {
+  --fa: "\f7b6";
+}
+
+.fa-car-battery {
+  --fa: "\f5df";
+}
+
+.fa-battery-car {
+  --fa: "\f5df";
+}
+
+.fa-gift {
+  --fa: "\f06b";
+}
+
+.fa-dice-two {
+  --fa: "\f528";
+}
+
+.fa-chess-queen {
+  --fa: "\f445";
+}
+
+.fa-glasses {
+  --fa: "\f530";
+}
+
+.fa-chess-board {
+  --fa: "\f43c";
+}
+
+.fa-building-circle-check {
+  --fa: "\e4d2";
+}
+
+.fa-person-chalkboard {
+  --fa: "\e53d";
+}
+
+.fa-mars-stroke-right {
+  --fa: "\f22b";
+}
+
+.fa-mars-stroke-h {
+  --fa: "\f22b";
+}
+
+.fa-hand-back-fist {
+  --fa: "\f255";
+}
+
+.fa-hand-rock {
+  --fa: "\f255";
+}
+
+.fa-square-caret-up {
+  --fa: "\f151";
+}
+
+.fa-caret-square-up {
+  --fa: "\f151";
+}
+
+.fa-cloud-showers-water {
+  --fa: "\e4e4";
+}
+
+.fa-chart-bar {
+  --fa: "\f080";
+}
+
+.fa-bar-chart {
+  --fa: "\f080";
+}
+
+.fa-hands-bubbles {
+  --fa: "\e05e";
+}
+
+.fa-hands-wash {
+  --fa: "\e05e";
+}
+
+.fa-less-than-equal {
+  --fa: "\f537";
+}
+
+.fa-train {
+  --fa: "\f238";
+}
+
+.fa-eye-low-vision {
+  --fa: "\f2a8";
+}
+
+.fa-low-vision {
+  --fa: "\f2a8";
+}
+
+.fa-crow {
+  --fa: "\f520";
+}
+
+.fa-sailboat {
+  --fa: "\e445";
+}
+
+.fa-window-restore {
+  --fa: "\f2d2";
+}
+
+.fa-square-plus {
+  --fa: "\f0fe";
+}
+
+.fa-plus-square {
+  --fa: "\f0fe";
+}
+
+.fa-torii-gate {
+  --fa: "\f6a1";
+}
+
+.fa-frog {
+  --fa: "\f52e";
+}
+
+.fa-bucket {
+  --fa: "\e4cf";
+}
+
+.fa-image {
+  --fa: "\f03e";
+}
+
+.fa-microphone {
+  --fa: "\f130";
+}
+
+.fa-cow {
+  --fa: "\f6c8";
+}
+
+.fa-caret-up {
+  --fa: "\f0d8";
+}
+
+.fa-screwdriver {
+  --fa: "\f54a";
+}
+
+.fa-folder-closed {
+  --fa: "\e185";
+}
+
+.fa-house-tsunami {
+  --fa: "\e515";
+}
+
+.fa-square-nfi {
+  --fa: "\e576";
+}
+
+.fa-arrow-up-from-ground-water {
+  --fa: "\e4b5";
+}
+
+.fa-martini-glass {
+  --fa: "\f57b";
+}
+
+.fa-glass-martini-alt {
+  --fa: "\f57b";
+}
+
+.fa-square-binary {
+  --fa: "\e69b";
+}
+
+.fa-rotate-left {
+  --fa: "\f2ea";
+}
+
+.fa-rotate-back {
+  --fa: "\f2ea";
+}
+
+.fa-rotate-backward {
+  --fa: "\f2ea";
+}
+
+.fa-undo-alt {
+  --fa: "\f2ea";
+}
+
+.fa-table-columns {
+  --fa: "\f0db";
+}
+
+.fa-columns {
+  --fa: "\f0db";
+}
+
+.fa-lemon {
+  --fa: "\f094";
+}
+
+.fa-head-side-mask {
+  --fa: "\e063";
+}
+
+.fa-handshake {
+  --fa: "\f2b5";
+}
+
+.fa-gem {
+  --fa: "\f3a5";
+}
+
+.fa-dolly {
+  --fa: "\f472";
+}
+
+.fa-dolly-box {
+  --fa: "\f472";
+}
+
+.fa-smoking {
+  --fa: "\f48d";
+}
+
+.fa-minimize {
+  --fa: "\f78c";
+}
+
+.fa-compress-arrows-alt {
+  --fa: "\f78c";
+}
+
+.fa-monument {
+  --fa: "\f5a6";
+}
+
+.fa-snowplow {
+  --fa: "\f7d2";
+}
+
+.fa-angles-right {
+  --fa: "\f101";
+}
+
+.fa-angle-double-right {
+  --fa: "\f101";
+}
+
+.fa-cannabis {
+  --fa: "\f55f";
+}
+
+.fa-circle-play {
+  --fa: "\f144";
+}
+
+.fa-play-circle {
+  --fa: "\f144";
+}
+
+.fa-tablets {
+  --fa: "\f490";
+}
+
+.fa-ethernet {
+  --fa: "\f796";
+}
+
+.fa-euro-sign {
+  --fa: "\f153";
+}
+
+.fa-eur {
+  --fa: "\f153";
+}
+
+.fa-euro {
+  --fa: "\f153";
+}
+
+.fa-chair {
+  --fa: "\f6c0";
+}
+
+.fa-circle-check {
+  --fa: "\f058";
+}
+
+.fa-check-circle {
+  --fa: "\f058";
+}
+
+.fa-circle-stop {
+  --fa: "\f28d";
+}
+
+.fa-stop-circle {
+  --fa: "\f28d";
+}
+
+.fa-compass-drafting {
+  --fa: "\f568";
+}
+
+.fa-drafting-compass {
+  --fa: "\f568";
+}
+
+.fa-plate-wheat {
+  --fa: "\e55a";
+}
+
+.fa-icicles {
+  --fa: "\f7ad";
+}
+
+.fa-person-shelter {
+  --fa: "\e54f";
+}
+
+.fa-neuter {
+  --fa: "\f22c";
+}
+
+.fa-id-badge {
+  --fa: "\f2c1";
+}
+
+.fa-marker {
+  --fa: "\f5a1";
+}
+
+.fa-face-laugh-beam {
+  --fa: "\f59a";
+}
+
+.fa-laugh-beam {
+  --fa: "\f59a";
+}
+
+.fa-helicopter-symbol {
+  --fa: "\e502";
+}
+
+.fa-universal-access {
+  --fa: "\f29a";
+}
+
+.fa-circle-chevron-up {
+  --fa: "\f139";
+}
+
+.fa-chevron-circle-up {
+  --fa: "\f139";
+}
+
+.fa-lari-sign {
+  --fa: "\e1c8";
+}
+
+.fa-volcano {
+  --fa: "\f770";
+}
+
+.fa-person-walking-dashed-line-arrow-right {
+  --fa: "\e553";
+}
+
+.fa-sterling-sign {
+  --fa: "\f154";
+}
+
+.fa-gbp {
+  --fa: "\f154";
+}
+
+.fa-pound-sign {
+  --fa: "\f154";
+}
+
+.fa-viruses {
+  --fa: "\e076";
+}
+
+.fa-square-person-confined {
+  --fa: "\e577";
+}
+
+.fa-user-tie {
+  --fa: "\f508";
+}
+
+.fa-arrow-down-long {
+  --fa: "\f175";
+}
+
+.fa-long-arrow-down {
+  --fa: "\f175";
+}
+
+.fa-tent-arrow-down-to-line {
+  --fa: "\e57e";
+}
+
+.fa-certificate {
+  --fa: "\f0a3";
+}
+
+.fa-reply-all {
+  --fa: "\f122";
+}
+
+.fa-mail-reply-all {
+  --fa: "\f122";
+}
+
+.fa-suitcase {
+  --fa: "\f0f2";
+}
+
+.fa-person-skating {
+  --fa: "\f7c5";
+}
+
+.fa-skating {
+  --fa: "\f7c5";
+}
+
+.fa-filter-circle-dollar {
+  --fa: "\f662";
+}
+
+.fa-funnel-dollar {
+  --fa: "\f662";
+}
+
+.fa-camera-retro {
+  --fa: "\f083";
+}
+
+.fa-circle-arrow-down {
+  --fa: "\f0ab";
+}
+
+.fa-arrow-circle-down {
+  --fa: "\f0ab";
+}
+
+.fa-file-import {
+  --fa: "\f56f";
+}
+
+.fa-arrow-right-to-file {
+  --fa: "\f56f";
+}
+
+.fa-square-arrow-up-right {
+  --fa: "\f14c";
+}
+
+.fa-external-link-square {
+  --fa: "\f14c";
+}
+
+.fa-box-open {
+  --fa: "\f49e";
+}
+
+.fa-scroll {
+  --fa: "\f70e";
+}
+
+.fa-spa {
+  --fa: "\f5bb";
+}
+
+.fa-location-pin-lock {
+  --fa: "\e51f";
+}
+
+.fa-pause {
+  --fa: "\f04c";
+}
+
+.fa-hill-avalanche {
+  --fa: "\e507";
+}
+
+.fa-temperature-empty {
+  --fa: "\f2cb";
+}
+
+.fa-temperature-0 {
+  --fa: "\f2cb";
+}
+
+.fa-thermometer-0 {
+  --fa: "\f2cb";
+}
+
+.fa-thermometer-empty {
+  --fa: "\f2cb";
+}
+
+.fa-bomb {
+  --fa: "\f1e2";
+}
+
+.fa-registered {
+  --fa: "\f25d";
+}
+
+.fa-address-card {
+  --fa: "\f2bb";
+}
+
+.fa-contact-card {
+  --fa: "\f2bb";
+}
+
+.fa-vcard {
+  --fa: "\f2bb";
+}
+
+.fa-scale-unbalanced-flip {
+  --fa: "\f516";
+}
+
+.fa-balance-scale-right {
+  --fa: "\f516";
+}
+
+.fa-subscript {
+  --fa: "\f12c";
+}
+
+.fa-diamond-turn-right {
+  --fa: "\f5eb";
+}
+
+.fa-directions {
+  --fa: "\f5eb";
+}
+
+.fa-burst {
+  --fa: "\e4dc";
+}
+
+.fa-house-laptop {
+  --fa: "\e066";
+}
+
+.fa-laptop-house {
+  --fa: "\e066";
+}
+
+.fa-face-tired {
+  --fa: "\f5c8";
+}
+
+.fa-tired {
+  --fa: "\f5c8";
+}
+
+.fa-money-bills {
+  --fa: "\e1f3";
+}
+
+.fa-smog {
+  --fa: "\f75f";
+}
+
+.fa-crutch {
+  --fa: "\f7f7";
+}
+
+.fa-cloud-arrow-up {
+  --fa: "\f0ee";
+}
+
+.fa-cloud-upload {
+  --fa: "\f0ee";
+}
+
+.fa-cloud-upload-alt {
+  --fa: "\f0ee";
+}
+
+.fa-palette {
+  --fa: "\f53f";
+}
+
+.fa-arrows-turn-right {
+  --fa: "\e4c0";
+}
+
+.fa-vest {
+  --fa: "\e085";
+}
+
+.fa-ferry {
+  --fa: "\e4ea";
+}
+
+.fa-arrows-down-to-people {
+  --fa: "\e4b9";
+}
+
+.fa-seedling {
+  --fa: "\f4d8";
+}
+
+.fa-sprout {
+  --fa: "\f4d8";
+}
+
+.fa-left-right {
+  --fa: "\f337";
+}
+
+.fa-arrows-alt-h {
+  --fa: "\f337";
+}
+
+.fa-boxes-packing {
+  --fa: "\e4c7";
+}
+
+.fa-circle-arrow-left {
+  --fa: "\f0a8";
+}
+
+.fa-arrow-circle-left {
+  --fa: "\f0a8";
+}
+
+.fa-group-arrows-rotate {
+  --fa: "\e4f6";
+}
+
+.fa-bowl-food {
+  --fa: "\e4c6";
+}
+
+.fa-candy-cane {
+  --fa: "\f786";
+}
+
+.fa-arrow-down-wide-short {
+  --fa: "\f160";
+}
+
+.fa-sort-amount-asc {
+  --fa: "\f160";
+}
+
+.fa-sort-amount-down {
+  --fa: "\f160";
+}
+
+.fa-cloud-bolt {
+  --fa: "\f76c";
+}
+
+.fa-thunderstorm {
+  --fa: "\f76c";
+}
+
+.fa-text-slash {
+  --fa: "\f87d";
+}
+
+.fa-remove-format {
+  --fa: "\f87d";
+}
+
+.fa-face-smile-wink {
+  --fa: "\f4da";
+}
+
+.fa-smile-wink {
+  --fa: "\f4da";
+}
+
+.fa-file-word {
+  --fa: "\f1c2";
+}
+
+.fa-file-powerpoint {
+  --fa: "\f1c4";
+}
+
+.fa-arrows-left-right {
+  --fa: "\f07e";
+}
+
+.fa-arrows-h {
+  --fa: "\f07e";
+}
+
+.fa-house-lock {
+  --fa: "\e510";
+}
+
+.fa-cloud-arrow-down {
+  --fa: "\f0ed";
+}
+
+.fa-cloud-download {
+  --fa: "\f0ed";
+}
+
+.fa-cloud-download-alt {
+  --fa: "\f0ed";
+}
+
+.fa-children {
+  --fa: "\e4e1";
+}
+
+.fa-chalkboard {
+  --fa: "\f51b";
+}
+
+.fa-blackboard {
+  --fa: "\f51b";
+}
+
+.fa-user-large-slash {
+  --fa: "\f4fa";
+}
+
+.fa-user-alt-slash {
+  --fa: "\f4fa";
+}
+
+.fa-envelope-open {
+  --fa: "\f2b6";
+}
+
+.fa-handshake-simple-slash {
+  --fa: "\e05f";
+}
+
+.fa-handshake-alt-slash {
+  --fa: "\e05f";
+}
+
+.fa-mattress-pillow {
+  --fa: "\e525";
+}
+
+.fa-guarani-sign {
+  --fa: "\e19a";
+}
+
+.fa-arrows-rotate {
+  --fa: "\f021";
+}
+
+.fa-refresh {
+  --fa: "\f021";
+}
+
+.fa-sync {
+  --fa: "\f021";
+}
+
+.fa-fire-extinguisher {
+  --fa: "\f134";
+}
+
+.fa-cruzeiro-sign {
+  --fa: "\e152";
+}
+
+.fa-greater-than-equal {
+  --fa: "\f532";
+}
+
+.fa-shield-halved {
+  --fa: "\f3ed";
+}
+
+.fa-shield-alt {
+  --fa: "\f3ed";
+}
+
+.fa-book-atlas {
+  --fa: "\f558";
+}
+
+.fa-atlas {
+  --fa: "\f558";
+}
+
+.fa-virus {
+  --fa: "\e074";
+}
+
+.fa-envelope-circle-check {
+  --fa: "\e4e8";
+}
+
+.fa-layer-group {
+  --fa: "\f5fd";
+}
+
+.fa-arrows-to-dot {
+  --fa: "\e4be";
+}
+
+.fa-archway {
+  --fa: "\f557";
+}
+
+.fa-heart-circle-check {
+  --fa: "\e4fd";
+}
+
+.fa-house-chimney-crack {
+  --fa: "\f6f1";
+}
+
+.fa-house-damage {
+  --fa: "\f6f1";
+}
+
+.fa-file-zipper {
+  --fa: "\f1c6";
+}
+
+.fa-file-archive {
+  --fa: "\f1c6";
+}
+
+.fa-square {
+  --fa: "\f0c8";
+}
+
+.fa-martini-glass-empty {
+  --fa: "\f000";
+}
+
+.fa-glass-martini {
+  --fa: "\f000";
+}
+
+.fa-couch {
+  --fa: "\f4b8";
+}
+
+.fa-cedi-sign {
+  --fa: "\e0df";
+}
+
+.fa-italic {
+  --fa: "\f033";
+}
+
+.fa-table-cells-column-lock {
+  --fa: "\e678";
+}
+
+.fa-church {
+  --fa: "\f51d";
+}
+
+.fa-comments-dollar {
+  --fa: "\f653";
+}
+
+.fa-democrat {
+  --fa: "\f747";
+}
+
+.fa-z {
+  --fa: "Z";
+}
+
+.fa-person-skiing {
+  --fa: "\f7c9";
+}
+
+.fa-skiing {
+  --fa: "\f7c9";
+}
+
+.fa-road-lock {
+  --fa: "\e567";
+}
+
+.fa-a {
+  --fa: "A";
+}
+
+.fa-temperature-arrow-down {
+  --fa: "\e03f";
+}
+
+.fa-temperature-down {
+  --fa: "\e03f";
+}
+
+.fa-feather-pointed {
+  --fa: "\f56b";
+}
+
+.fa-feather-alt {
+  --fa: "\f56b";
+}
+
+.fa-p {
+  --fa: "P";
+}
+
+.fa-snowflake {
+  --fa: "\f2dc";
+}
+
+.fa-newspaper {
+  --fa: "\f1ea";
+}
+
+.fa-rectangle-ad {
+  --fa: "\f641";
+}
+
+.fa-ad {
+  --fa: "\f641";
+}
+
+.fa-circle-arrow-right {
+  --fa: "\f0a9";
+}
+
+.fa-arrow-circle-right {
+  --fa: "\f0a9";
+}
+
+.fa-filter-circle-xmark {
+  --fa: "\e17b";
+}
+
+.fa-locust {
+  --fa: "\e520";
+}
+
+.fa-sort {
+  --fa: "\f0dc";
+}
+
+.fa-unsorted {
+  --fa: "\f0dc";
+}
+
+.fa-list-ol {
+  --fa: "\f0cb";
+}
+
+.fa-list-1-2 {
+  --fa: "\f0cb";
+}
+
+.fa-list-numeric {
+  --fa: "\f0cb";
+}
+
+.fa-person-dress-burst {
+  --fa: "\e544";
+}
+
+.fa-money-check-dollar {
+  --fa: "\f53d";
+}
+
+.fa-money-check-alt {
+  --fa: "\f53d";
+}
+
+.fa-vector-square {
+  --fa: "\f5cb";
+}
+
+.fa-bread-slice {
+  --fa: "\f7ec";
+}
+
+.fa-language {
+  --fa: "\f1ab";
+}
+
+.fa-face-kiss-wink-heart {
+  --fa: "\f598";
+}
+
+.fa-kiss-wink-heart {
+  --fa: "\f598";
+}
+
+.fa-filter {
+  --fa: "\f0b0";
+}
+
+.fa-question {
+  --fa: "\?";
+}
+
+.fa-file-signature {
+  --fa: "\f573";
+}
+
+.fa-up-down-left-right {
+  --fa: "\f0b2";
+}
+
+.fa-arrows-alt {
+  --fa: "\f0b2";
+}
+
+.fa-house-chimney-user {
+  --fa: "\e065";
+}
+
+.fa-hand-holding-heart {
+  --fa: "\f4be";
+}
+
+.fa-puzzle-piece {
+  --fa: "\f12e";
+}
+
+.fa-money-check {
+  --fa: "\f53c";
+}
+
+.fa-star-half-stroke {
+  --fa: "\f5c0";
+}
+
+.fa-star-half-alt {
+  --fa: "\f5c0";
+}
+
+.fa-code {
+  --fa: "\f121";
+}
+
+.fa-whiskey-glass {
+  --fa: "\f7a0";
+}
+
+.fa-glass-whiskey {
+  --fa: "\f7a0";
+}
+
+.fa-building-circle-exclamation {
+  --fa: "\e4d3";
+}
+
+.fa-magnifying-glass-chart {
+  --fa: "\e522";
+}
+
+.fa-arrow-up-right-from-square {
+  --fa: "\f08e";
+}
+
+.fa-external-link {
+  --fa: "\f08e";
+}
+
+.fa-cubes-stacked {
+  --fa: "\e4e6";
+}
+
+.fa-won-sign {
+  --fa: "\f159";
+}
+
+.fa-krw {
+  --fa: "\f159";
+}
+
+.fa-won {
+  --fa: "\f159";
+}
+
+.fa-virus-covid {
+  --fa: "\e4a8";
+}
+
+.fa-austral-sign {
+  --fa: "\e0a9";
+}
+
+.fa-f {
+  --fa: "F";
+}
+
+.fa-leaf {
+  --fa: "\f06c";
+}
+
+.fa-road {
+  --fa: "\f018";
+}
+
+.fa-taxi {
+  --fa: "\f1ba";
+}
+
+.fa-cab {
+  --fa: "\f1ba";
+}
+
+.fa-person-circle-plus {
+  --fa: "\e541";
+}
+
+.fa-chart-pie {
+  --fa: "\f200";
+}
+
+.fa-pie-chart {
+  --fa: "\f200";
+}
+
+.fa-bolt-lightning {
+  --fa: "\e0b7";
+}
+
+.fa-sack-xmark {
+  --fa: "\e56a";
+}
+
+.fa-file-excel {
+  --fa: "\f1c3";
+}
+
+.fa-file-contract {
+  --fa: "\f56c";
+}
+
+.fa-fish-fins {
+  --fa: "\e4f2";
+}
+
+.fa-building-flag {
+  --fa: "\e4d5";
+}
+
+.fa-face-grin-beam {
+  --fa: "\f582";
+}
+
+.fa-grin-beam {
+  --fa: "\f582";
+}
+
+.fa-object-ungroup {
+  --fa: "\f248";
+}
+
+.fa-poop {
+  --fa: "\f619";
+}
+
+.fa-location-pin {
+  --fa: "\f041";
+}
+
+.fa-map-marker {
+  --fa: "\f041";
+}
+
+.fa-kaaba {
+  --fa: "\f66b";
+}
+
+.fa-toilet-paper {
+  --fa: "\f71e";
+}
+
+.fa-helmet-safety {
+  --fa: "\f807";
+}
+
+.fa-hard-hat {
+  --fa: "\f807";
+}
+
+.fa-hat-hard {
+  --fa: "\f807";
+}
+
+.fa-eject {
+  --fa: "\f052";
+}
+
+.fa-circle-right {
+  --fa: "\f35a";
+}
+
+.fa-arrow-alt-circle-right {
+  --fa: "\f35a";
+}
+
+.fa-plane-circle-check {
+  --fa: "\e555";
+}
+
+.fa-face-rolling-eyes {
+  --fa: "\f5a5";
+}
+
+.fa-meh-rolling-eyes {
+  --fa: "\f5a5";
+}
+
+.fa-object-group {
+  --fa: "\f247";
+}
+
+.fa-chart-line {
+  --fa: "\f201";
+}
+
+.fa-line-chart {
+  --fa: "\f201";
+}
+
+.fa-mask-ventilator {
+  --fa: "\e524";
+}
+
+.fa-arrow-right {
+  --fa: "\f061";
+}
+
+.fa-signs-post {
+  --fa: "\f277";
+}
+
+.fa-map-signs {
+  --fa: "\f277";
+}
+
+.fa-cash-register {
+  --fa: "\f788";
+}
+
+.fa-person-circle-question {
+  --fa: "\e542";
+}
+
+.fa-h {
+  --fa: "H";
+}
+
+.fa-tarp {
+  --fa: "\e57b";
+}
+
+.fa-screwdriver-wrench {
+  --fa: "\f7d9";
+}
+
+.fa-tools {
+  --fa: "\f7d9";
+}
+
+.fa-arrows-to-eye {
+  --fa: "\e4bf";
+}
+
+.fa-plug-circle-bolt {
+  --fa: "\e55b";
+}
+
+.fa-heart {
+  --fa: "\f004";
+}
+
+.fa-mars-and-venus {
+  --fa: "\f224";
+}
+
+.fa-house-user {
+  --fa: "\e1b0";
+}
+
+.fa-home-user {
+  --fa: "\e1b0";
+}
+
+.fa-dumpster-fire {
+  --fa: "\f794";
+}
+
+.fa-house-crack {
+  --fa: "\e3b1";
+}
+
+.fa-martini-glass-citrus {
+  --fa: "\f561";
+}
+
+.fa-cocktail {
+  --fa: "\f561";
+}
+
+.fa-face-surprise {
+  --fa: "\f5c2";
+}
+
+.fa-surprise {
+  --fa: "\f5c2";
+}
+
+.fa-bottle-water {
+  --fa: "\e4c5";
+}
+
+.fa-circle-pause {
+  --fa: "\f28b";
+}
+
+.fa-pause-circle {
+  --fa: "\f28b";
+}
+
+.fa-toilet-paper-slash {
+  --fa: "\e072";
+}
+
+.fa-apple-whole {
+  --fa: "\f5d1";
+}
+
+.fa-apple-alt {
+  --fa: "\f5d1";
+}
+
+.fa-kitchen-set {
+  --fa: "\e51a";
+}
+
+.fa-r {
+  --fa: "R";
+}
+
+.fa-temperature-quarter {
+  --fa: "\f2ca";
+}
+
+.fa-temperature-1 {
+  --fa: "\f2ca";
+}
+
+.fa-thermometer-1 {
+  --fa: "\f2ca";
+}
+
+.fa-thermometer-quarter {
+  --fa: "\f2ca";
+}
+
+.fa-cube {
+  --fa: "\f1b2";
+}
+
+.fa-bitcoin-sign {
+  --fa: "\e0b4";
+}
+
+.fa-shield-dog {
+  --fa: "\e573";
+}
+
+.fa-solar-panel {
+  --fa: "\f5ba";
+}
+
+.fa-lock-open {
+  --fa: "\f3c1";
+}
+
+.fa-elevator {
+  --fa: "\e16d";
+}
+
+.fa-money-bill-transfer {
+  --fa: "\e528";
+}
+
+.fa-money-bill-trend-up {
+  --fa: "\e529";
+}
+
+.fa-house-flood-water-circle-arrow-right {
+  --fa: "\e50f";
+}
+
+.fa-square-poll-horizontal {
+  --fa: "\f682";
+}
+
+.fa-poll-h {
+  --fa: "\f682";
+}
+
+.fa-circle {
+  --fa: "\f111";
+}
+
+.fa-backward-fast {
+  --fa: "\f049";
+}
+
+.fa-fast-backward {
+  --fa: "\f049";
+}
+
+.fa-recycle {
+  --fa: "\f1b8";
+}
+
+.fa-user-astronaut {
+  --fa: "\f4fb";
+}
+
+.fa-plane-slash {
+  --fa: "\e069";
+}
+
+.fa-trademark {
+  --fa: "\f25c";
+}
+
+.fa-basketball {
+  --fa: "\f434";
+}
+
+.fa-basketball-ball {
+  --fa: "\f434";
+}
+
+.fa-satellite-dish {
+  --fa: "\f7c0";
+}
+
+.fa-circle-up {
+  --fa: "\f35b";
+}
+
+.fa-arrow-alt-circle-up {
+  --fa: "\f35b";
+}
+
+.fa-mobile-screen-button {
+  --fa: "\f3cd";
+}
+
+.fa-mobile-alt {
+  --fa: "\f3cd";
+}
+
+.fa-volume-high {
+  --fa: "\f028";
+}
+
+.fa-volume-up {
+  --fa: "\f028";
+}
+
+.fa-users-rays {
+  --fa: "\e593";
+}
+
+.fa-wallet {
+  --fa: "\f555";
+}
+
+.fa-clipboard-check {
+  --fa: "\f46c";
+}
+
+.fa-file-audio {
+  --fa: "\f1c7";
+}
+
+.fa-burger {
+  --fa: "\f805";
+}
+
+.fa-hamburger {
+  --fa: "\f805";
+}
+
+.fa-wrench {
+  --fa: "\f0ad";
+}
+
+.fa-bugs {
+  --fa: "\e4d0";
+}
+
+.fa-rupee-sign {
+  --fa: "\f156";
+}
+
+.fa-rupee {
+  --fa: "\f156";
+}
+
+.fa-file-image {
+  --fa: "\f1c5";
+}
+
+.fa-circle-question {
+  --fa: "\f059";
+}
+
+.fa-question-circle {
+  --fa: "\f059";
+}
+
+.fa-plane-departure {
+  --fa: "\f5b0";
+}
+
+.fa-handshake-slash {
+  --fa: "\e060";
+}
+
+.fa-book-bookmark {
+  --fa: "\e0bb";
+}
+
+.fa-code-branch {
+  --fa: "\f126";
+}
+
+.fa-hat-cowboy {
+  --fa: "\f8c0";
+}
+
+.fa-bridge {
+  --fa: "\e4c8";
+}
+
+.fa-phone-flip {
+  --fa: "\f879";
+}
+
+.fa-phone-alt {
+  --fa: "\f879";
+}
+
+.fa-truck-front {
+  --fa: "\e2b7";
+}
+
+.fa-cat {
+  --fa: "\f6be";
+}
+
+.fa-anchor-circle-exclamation {
+  --fa: "\e4ab";
+}
+
+.fa-truck-field {
+  --fa: "\e58d";
+}
+
+.fa-route {
+  --fa: "\f4d7";
+}
+
+.fa-clipboard-question {
+  --fa: "\e4e3";
+}
+
+.fa-panorama {
+  --fa: "\e209";
+}
+
+.fa-comment-medical {
+  --fa: "\f7f5";
+}
+
+.fa-teeth-open {
+  --fa: "\f62f";
+}
+
+.fa-file-circle-minus {
+  --fa: "\e4ed";
+}
+
+.fa-tags {
+  --fa: "\f02c";
+}
+
+.fa-wine-glass {
+  --fa: "\f4e3";
+}
+
+.fa-forward-fast {
+  --fa: "\f050";
+}
+
+.fa-fast-forward {
+  --fa: "\f050";
+}
+
+.fa-face-meh-blank {
+  --fa: "\f5a4";
+}
+
+.fa-meh-blank {
+  --fa: "\f5a4";
+}
+
+.fa-square-parking {
+  --fa: "\f540";
+}
+
+.fa-parking {
+  --fa: "\f540";
+}
+
+.fa-house-signal {
+  --fa: "\e012";
+}
+
+.fa-bars-progress {
+  --fa: "\f828";
+}
+
+.fa-tasks-alt {
+  --fa: "\f828";
+}
+
+.fa-faucet-drip {
+  --fa: "\e006";
+}
+
+.fa-cart-flatbed {
+  --fa: "\f474";
+}
+
+.fa-dolly-flatbed {
+  --fa: "\f474";
+}
+
+.fa-ban-smoking {
+  --fa: "\f54d";
+}
+
+.fa-smoking-ban {
+  --fa: "\f54d";
+}
+
+.fa-terminal {
+  --fa: "\f120";
+}
+
+.fa-mobile-button {
+  --fa: "\f10b";
+}
+
+.fa-house-medical-flag {
+  --fa: "\e514";
+}
+
+.fa-basket-shopping {
+  --fa: "\f291";
+}
+
+.fa-shopping-basket {
+  --fa: "\f291";
+}
+
+.fa-tape {
+  --fa: "\f4db";
+}
+
+.fa-bus-simple {
+  --fa: "\f55e";
+}
+
+.fa-bus-alt {
+  --fa: "\f55e";
+}
+
+.fa-eye {
+  --fa: "\f06e";
+}
+
+.fa-face-sad-cry {
+  --fa: "\f5b3";
+}
+
+.fa-sad-cry {
+  --fa: "\f5b3";
+}
+
+.fa-audio-description {
+  --fa: "\f29e";
+}
+
+.fa-person-military-to-person {
+  --fa: "\e54c";
+}
+
+.fa-file-shield {
+  --fa: "\e4f0";
+}
+
+.fa-user-slash {
+  --fa: "\f506";
+}
+
+.fa-pen {
+  --fa: "\f304";
+}
+
+.fa-tower-observation {
+  --fa: "\e586";
+}
+
+.fa-file-code {
+  --fa: "\f1c9";
+}
+
+.fa-signal {
+  --fa: "\f012";
+}
+
+.fa-signal-5 {
+  --fa: "\f012";
+}
+
+.fa-signal-perfect {
+  --fa: "\f012";
+}
+
+.fa-bus {
+  --fa: "\f207";
+}
+
+.fa-heart-circle-xmark {
+  --fa: "\e501";
+}
+
+.fa-house-chimney {
+  --fa: "\e3af";
+}
+
+.fa-home-lg {
+  --fa: "\e3af";
+}
+
+.fa-window-maximize {
+  --fa: "\f2d0";
+}
+
+.fa-face-frown {
+  --fa: "\f119";
+}
+
+.fa-frown {
+  --fa: "\f119";
+}
+
+.fa-prescription {
+  --fa: "\f5b1";
+}
+
+.fa-shop {
+  --fa: "\f54f";
+}
+
+.fa-store-alt {
+  --fa: "\f54f";
+}
+
+.fa-floppy-disk {
+  --fa: "\f0c7";
+}
+
+.fa-save {
+  --fa: "\f0c7";
+}
+
+.fa-vihara {
+  --fa: "\f6a7";
+}
+
+.fa-scale-unbalanced {
+  --fa: "\f515";
+}
+
+.fa-balance-scale-left {
+  --fa: "\f515";
+}
+
+.fa-sort-up {
+  --fa: "\f0de";
+}
+
+.fa-sort-asc {
+  --fa: "\f0de";
+}
+
+.fa-comment-dots {
+  --fa: "\f4ad";
+}
+
+.fa-commenting {
+  --fa: "\f4ad";
+}
+
+.fa-plant-wilt {
+  --fa: "\e5aa";
+}
+
+.fa-diamond {
+  --fa: "\f219";
+}
+
+.fa-face-grin-squint {
+  --fa: "\f585";
+}
+
+.fa-grin-squint {
+  --fa: "\f585";
+}
+
+.fa-hand-holding-dollar {
+  --fa: "\f4c0";
+}
+
+.fa-hand-holding-usd {
+  --fa: "\f4c0";
+}
+
+.fa-chart-diagram {
+  --fa: "\e695";
+}
+
+.fa-bacterium {
+  --fa: "\e05a";
+}
+
+.fa-hand-pointer {
+  --fa: "\f25a";
+}
+
+.fa-drum-steelpan {
+  --fa: "\f56a";
+}
+
+.fa-hand-scissors {
+  --fa: "\f257";
+}
+
+.fa-hands-praying {
+  --fa: "\f684";
+}
+
+.fa-praying-hands {
+  --fa: "\f684";
+}
+
+.fa-arrow-rotate-right {
+  --fa: "\f01e";
+}
+
+.fa-arrow-right-rotate {
+  --fa: "\f01e";
+}
+
+.fa-arrow-rotate-forward {
+  --fa: "\f01e";
+}
+
+.fa-redo {
+  --fa: "\f01e";
+}
+
+.fa-biohazard {
+  --fa: "\f780";
+}
+
+.fa-location-crosshairs {
+  --fa: "\f601";
+}
+
+.fa-location {
+  --fa: "\f601";
+}
+
+.fa-mars-double {
+  --fa: "\f227";
+}
+
+.fa-child-dress {
+  --fa: "\e59c";
+}
+
+.fa-users-between-lines {
+  --fa: "\e591";
+}
+
+.fa-lungs-virus {
+  --fa: "\e067";
+}
+
+.fa-face-grin-tears {
+  --fa: "\f588";
+}
+
+.fa-grin-tears {
+  --fa: "\f588";
+}
+
+.fa-phone {
+  --fa: "\f095";
+}
+
+.fa-calendar-xmark {
+  --fa: "\f273";
+}
+
+.fa-calendar-times {
+  --fa: "\f273";
+}
+
+.fa-child-reaching {
+  --fa: "\e59d";
+}
+
+.fa-head-side-virus {
+  --fa: "\e064";
+}
+
+.fa-user-gear {
+  --fa: "\f4fe";
+}
+
+.fa-user-cog {
+  --fa: "\f4fe";
+}
+
+.fa-arrow-up-1-9 {
+  --fa: "\f163";
+}
+
+.fa-sort-numeric-up {
+  --fa: "\f163";
+}
+
+.fa-door-closed {
+  --fa: "\f52a";
+}
+
+.fa-shield-virus {
+  --fa: "\e06c";
+}
+
+.fa-dice-six {
+  --fa: "\f526";
+}
+
+.fa-mosquito-net {
+  --fa: "\e52c";
+}
+
+.fa-file-fragment {
+  --fa: "\e697";
+}
+
+.fa-bridge-water {
+  --fa: "\e4ce";
+}
+
+.fa-person-booth {
+  --fa: "\f756";
+}
+
+.fa-text-width {
+  --fa: "\f035";
+}
+
+.fa-hat-wizard {
+  --fa: "\f6e8";
+}
+
+.fa-pen-fancy {
+  --fa: "\f5ac";
+}
+
+.fa-person-digging {
+  --fa: "\f85e";
+}
+
+.fa-digging {
+  --fa: "\f85e";
+}
+
+.fa-trash {
+  --fa: "\f1f8";
+}
+
+.fa-gauge-simple {
+  --fa: "\f629";
+}
+
+.fa-gauge-simple-med {
+  --fa: "\f629";
+}
+
+.fa-tachometer-average {
+  --fa: "\f629";
+}
+
+.fa-book-medical {
+  --fa: "\f7e6";
+}
+
+.fa-poo {
+  --fa: "\f2fe";
+}
+
+.fa-quote-right {
+  --fa: "\f10e";
+}
+
+.fa-quote-right-alt {
+  --fa: "\f10e";
+}
+
+.fa-shirt {
+  --fa: "\f553";
+}
+
+.fa-t-shirt {
+  --fa: "\f553";
+}
+
+.fa-tshirt {
+  --fa: "\f553";
+}
+
+.fa-cubes {
+  --fa: "\f1b3";
+}
+
+.fa-divide {
+  --fa: "\f529";
+}
+
+.fa-tenge-sign {
+  --fa: "\f7d7";
+}
+
+.fa-tenge {
+  --fa: "\f7d7";
+}
+
+.fa-headphones {
+  --fa: "\f025";
+}
+
+.fa-hands-holding {
+  --fa: "\f4c2";
+}
+
+.fa-hands-clapping {
+  --fa: "\e1a8";
+}
+
+.fa-republican {
+  --fa: "\f75e";
+}
+
+.fa-arrow-left {
+  --fa: "\f060";
+}
+
+.fa-person-circle-xmark {
+  --fa: "\e543";
+}
+
+.fa-ruler {
+  --fa: "\f545";
+}
+
+.fa-align-left {
+  --fa: "\f036";
+}
+
+.fa-dice-d6 {
+  --fa: "\f6d1";
+}
+
+.fa-restroom {
+  --fa: "\f7bd";
+}
+
+.fa-j {
+  --fa: "J";
+}
+
+.fa-users-viewfinder {
+  --fa: "\e595";
+}
+
+.fa-file-video {
+  --fa: "\f1c8";
+}
+
+.fa-up-right-from-square {
+  --fa: "\f35d";
+}
+
+.fa-external-link-alt {
+  --fa: "\f35d";
+}
+
+.fa-table-cells {
+  --fa: "\f00a";
+}
+
+.fa-th {
+  --fa: "\f00a";
+}
+
+.fa-file-pdf {
+  --fa: "\f1c1";
+}
+
+.fa-book-bible {
+  --fa: "\f647";
+}
+
+.fa-bible {
+  --fa: "\f647";
+}
+
+.fa-o {
+  --fa: "O";
+}
+
+.fa-suitcase-medical {
+  --fa: "\f0fa";
+}
+
+.fa-medkit {
+  --fa: "\f0fa";
+}
+
+.fa-user-secret {
+  --fa: "\f21b";
+}
+
+.fa-otter {
+  --fa: "\f700";
+}
+
+.fa-person-dress {
+  --fa: "\f182";
+}
+
+.fa-female {
+  --fa: "\f182";
+}
+
+.fa-comment-dollar {
+  --fa: "\f651";
+}
+
+.fa-business-time {
+  --fa: "\f64a";
+}
+
+.fa-briefcase-clock {
+  --fa: "\f64a";
+}
+
+.fa-table-cells-large {
+  --fa: "\f009";
+}
+
+.fa-th-large {
+  --fa: "\f009";
+}
+
+.fa-book-tanakh {
+  --fa: "\f827";
+}
+
+.fa-tanakh {
+  --fa: "\f827";
+}
+
+.fa-phone-volume {
+  --fa: "\f2a0";
+}
+
+.fa-volume-control-phone {
+  --fa: "\f2a0";
+}
+
+.fa-hat-cowboy-side {
+  --fa: "\f8c1";
+}
+
+.fa-clipboard-user {
+  --fa: "\f7f3";
+}
+
+.fa-child {
+  --fa: "\f1ae";
+}
+
+.fa-lira-sign {
+  --fa: "\f195";
+}
+
+.fa-satellite {
+  --fa: "\f7bf";
+}
+
+.fa-plane-lock {
+  --fa: "\e558";
+}
+
+.fa-tag {
+  --fa: "\f02b";
+}
+
+.fa-comment {
+  --fa: "\f075";
+}
+
+.fa-cake-candles {
+  --fa: "\f1fd";
+}
+
+.fa-birthday-cake {
+  --fa: "\f1fd";
+}
+
+.fa-cake {
+  --fa: "\f1fd";
+}
+
+.fa-envelope {
+  --fa: "\f0e0";
+}
+
+.fa-angles-up {
+  --fa: "\f102";
+}
+
+.fa-angle-double-up {
+  --fa: "\f102";
+}
+
+.fa-paperclip {
+  --fa: "\f0c6";
+}
+
+.fa-arrow-right-to-city {
+  --fa: "\e4b3";
+}
+
+.fa-ribbon {
+  --fa: "\f4d6";
+}
+
+.fa-lungs {
+  --fa: "\f604";
+}
+
+.fa-arrow-up-9-1 {
+  --fa: "\f887";
+}
+
+.fa-sort-numeric-up-alt {
+  --fa: "\f887";
+}
+
+.fa-litecoin-sign {
+  --fa: "\e1d3";
+}
+
+.fa-border-none {
+  --fa: "\f850";
+}
+
+.fa-circle-nodes {
+  --fa: "\e4e2";
+}
+
+.fa-parachute-box {
+  --fa: "\f4cd";
+}
+
+.fa-indent {
+  --fa: "\f03c";
+}
+
+.fa-truck-field-un {
+  --fa: "\e58e";
+}
+
+.fa-hourglass {
+  --fa: "\f254";
+}
+
+.fa-hourglass-empty {
+  --fa: "\f254";
+}
+
+.fa-mountain {
+  --fa: "\f6fc";
+}
+
+.fa-user-doctor {
+  --fa: "\f0f0";
+}
+
+.fa-user-md {
+  --fa: "\f0f0";
+}
+
+.fa-circle-info {
+  --fa: "\f05a";
+}
+
+.fa-info-circle {
+  --fa: "\f05a";
+}
+
+.fa-cloud-meatball {
+  --fa: "\f73b";
+}
+
+.fa-camera {
+  --fa: "\f030";
+}
+
+.fa-camera-alt {
+  --fa: "\f030";
+}
+
+.fa-square-virus {
+  --fa: "\e578";
+}
+
+.fa-meteor {
+  --fa: "\f753";
+}
+
+.fa-car-on {
+  --fa: "\e4dd";
+}
+
+.fa-sleigh {
+  --fa: "\f7cc";
+}
+
+.fa-arrow-down-1-9 {
+  --fa: "\f162";
+}
+
+.fa-sort-numeric-asc {
+  --fa: "\f162";
+}
+
+.fa-sort-numeric-down {
+  --fa: "\f162";
+}
+
+.fa-hand-holding-droplet {
+  --fa: "\f4c1";
+}
+
+.fa-hand-holding-water {
+  --fa: "\f4c1";
+}
+
+.fa-water {
+  --fa: "\f773";
+}
+
+.fa-calendar-check {
+  --fa: "\f274";
+}
+
+.fa-braille {
+  --fa: "\f2a1";
+}
+
+.fa-prescription-bottle-medical {
+  --fa: "\f486";
+}
+
+.fa-prescription-bottle-alt {
+  --fa: "\f486";
+}
+
+.fa-landmark {
+  --fa: "\f66f";
+}
+
+.fa-truck {
+  --fa: "\f0d1";
+}
+
+.fa-crosshairs {
+  --fa: "\f05b";
+}
+
+.fa-person-cane {
+  --fa: "\e53c";
+}
+
+.fa-tent {
+  --fa: "\e57d";
+}
+
+.fa-vest-patches {
+  --fa: "\e086";
+}
+
+.fa-check-double {
+  --fa: "\f560";
+}
+
+.fa-arrow-down-a-z {
+  --fa: "\f15d";
+}
+
+.fa-sort-alpha-asc {
+  --fa: "\f15d";
+}
+
+.fa-sort-alpha-down {
+  --fa: "\f15d";
+}
+
+.fa-money-bill-wheat {
+  --fa: "\e52a";
+}
+
+.fa-cookie {
+  --fa: "\f563";
+}
+
+.fa-arrow-rotate-left {
+  --fa: "\f0e2";
+}
+
+.fa-arrow-left-rotate {
+  --fa: "\f0e2";
+}
+
+.fa-arrow-rotate-back {
+  --fa: "\f0e2";
+}
+
+.fa-arrow-rotate-backward {
+  --fa: "\f0e2";
+}
+
+.fa-undo {
+  --fa: "\f0e2";
+}
+
+.fa-hard-drive {
+  --fa: "\f0a0";
+}
+
+.fa-hdd {
+  --fa: "\f0a0";
+}
+
+.fa-face-grin-squint-tears {
+  --fa: "\f586";
+}
+
+.fa-grin-squint-tears {
+  --fa: "\f586";
+}
+
+.fa-dumbbell {
+  --fa: "\f44b";
+}
+
+.fa-rectangle-list {
+  --fa: "\f022";
+}
+
+.fa-list-alt {
+  --fa: "\f022";
+}
+
+.fa-tarp-droplet {
+  --fa: "\e57c";
+}
+
+.fa-house-medical-circle-check {
+  --fa: "\e511";
+}
+
+.fa-person-skiing-nordic {
+  --fa: "\f7ca";
+}
+
+.fa-skiing-nordic {
+  --fa: "\f7ca";
+}
+
+.fa-calendar-plus {
+  --fa: "\f271";
+}
+
+.fa-plane-arrival {
+  --fa: "\f5af";
+}
+
+.fa-circle-left {
+  --fa: "\f359";
+}
+
+.fa-arrow-alt-circle-left {
+  --fa: "\f359";
+}
+
+.fa-train-subway {
+  --fa: "\f239";
+}
+
+.fa-subway {
+  --fa: "\f239";
+}
+
+.fa-chart-gantt {
+  --fa: "\e0e4";
+}
+
+.fa-indian-rupee-sign {
+  --fa: "\e1bc";
+}
+
+.fa-indian-rupee {
+  --fa: "\e1bc";
+}
+
+.fa-inr {
+  --fa: "\e1bc";
+}
+
+.fa-crop-simple {
+  --fa: "\f565";
+}
+
+.fa-crop-alt {
+  --fa: "\f565";
+}
+
+.fa-money-bill-1 {
+  --fa: "\f3d1";
+}
+
+.fa-money-bill-alt {
+  --fa: "\f3d1";
+}
+
+.fa-left-long {
+  --fa: "\f30a";
+}
+
+.fa-long-arrow-alt-left {
+  --fa: "\f30a";
+}
+
+.fa-dna {
+  --fa: "\f471";
+}
+
+.fa-virus-slash {
+  --fa: "\e075";
+}
+
+.fa-minus {
+  --fa: "\f068";
+}
+
+.fa-subtract {
+  --fa: "\f068";
+}
+
+.fa-chess {
+  --fa: "\f439";
+}
+
+.fa-arrow-left-long {
+  --fa: "\f177";
+}
+
+.fa-long-arrow-left {
+  --fa: "\f177";
+}
+
+.fa-plug-circle-check {
+  --fa: "\e55c";
+}
+
+.fa-street-view {
+  --fa: "\f21d";
+}
+
+.fa-franc-sign {
+  --fa: "\e18f";
+}
+
+.fa-volume-off {
+  --fa: "\f026";
+}
+
+.fa-hands-asl-interpreting {
+  --fa: "\f2a3";
+}
+
+.fa-american-sign-language-interpreting {
+  --fa: "\f2a3";
+}
+
+.fa-asl-interpreting {
+  --fa: "\f2a3";
+}
+
+.fa-hands-american-sign-language-interpreting {
+  --fa: "\f2a3";
+}
+
+.fa-gear {
+  --fa: "\f013";
+}
+
+.fa-cog {
+  --fa: "\f013";
+}
+
+.fa-droplet-slash {
+  --fa: "\f5c7";
+}
+
+.fa-tint-slash {
+  --fa: "\f5c7";
+}
+
+.fa-mosque {
+  --fa: "\f678";
+}
+
+.fa-mosquito {
+  --fa: "\e52b";
+}
+
+.fa-star-of-david {
+  --fa: "\f69a";
+}
+
+.fa-person-military-rifle {
+  --fa: "\e54b";
+}
+
+.fa-cart-shopping {
+  --fa: "\f07a";
+}
+
+.fa-shopping-cart {
+  --fa: "\f07a";
+}
+
+.fa-vials {
+  --fa: "\f493";
+}
+
+.fa-plug-circle-plus {
+  --fa: "\e55f";
+}
+
+.fa-place-of-worship {
+  --fa: "\f67f";
+}
+
+.fa-grip-vertical {
+  --fa: "\f58e";
+}
+
+.fa-hexagon-nodes {
+  --fa: "\e699";
+}
+
+.fa-arrow-turn-up {
+  --fa: "\f148";
+}
+
+.fa-level-up {
+  --fa: "\f148";
+}
+
+.fa-u {
+  --fa: "U";
+}
+
+.fa-square-root-variable {
+  --fa: "\f698";
+}
+
+.fa-square-root-alt {
+  --fa: "\f698";
+}
+
+.fa-clock {
+  --fa: "\f017";
+}
+
+.fa-clock-four {
+  --fa: "\f017";
+}
+
+.fa-backward-step {
+  --fa: "\f048";
+}
+
+.fa-step-backward {
+  --fa: "\f048";
+}
+
+.fa-pallet {
+  --fa: "\f482";
+}
+
+.fa-faucet {
+  --fa: "\e005";
+}
+
+.fa-baseball-bat-ball {
+  --fa: "\f432";
+}
+
+.fa-s {
+  --fa: "S";
+}
+
+.fa-timeline {
+  --fa: "\e29c";
+}
+
+.fa-keyboard {
+  --fa: "\f11c";
+}
+
+.fa-caret-down {
+  --fa: "\f0d7";
+}
+
+.fa-house-chimney-medical {
+  --fa: "\f7f2";
+}
+
+.fa-clinic-medical {
+  --fa: "\f7f2";
+}
+
+.fa-temperature-three-quarters {
+  --fa: "\f2c8";
+}
+
+.fa-temperature-3 {
+  --fa: "\f2c8";
+}
+
+.fa-thermometer-3 {
+  --fa: "\f2c8";
+}
+
+.fa-thermometer-three-quarters {
+  --fa: "\f2c8";
+}
+
+.fa-mobile-screen {
+  --fa: "\f3cf";
+}
+
+.fa-mobile-android-alt {
+  --fa: "\f3cf";
+}
+
+.fa-plane-up {
+  --fa: "\e22d";
+}
+
+.fa-piggy-bank {
+  --fa: "\f4d3";
+}
+
+.fa-battery-half {
+  --fa: "\f242";
+}
+
+.fa-battery-3 {
+  --fa: "\f242";
+}
+
+.fa-mountain-city {
+  --fa: "\e52e";
+}
+
+.fa-coins {
+  --fa: "\f51e";
+}
+
+.fa-khanda {
+  --fa: "\f66d";
+}
+
+.fa-sliders {
+  --fa: "\f1de";
+}
+
+.fa-sliders-h {
+  --fa: "\f1de";
+}
+
+.fa-folder-tree {
+  --fa: "\f802";
+}
+
+.fa-network-wired {
+  --fa: "\f6ff";
+}
+
+.fa-map-pin {
+  --fa: "\f276";
+}
+
+.fa-hamsa {
+  --fa: "\f665";
+}
+
+.fa-cent-sign {
+  --fa: "\e3f5";
+}
+
+.fa-flask {
+  --fa: "\f0c3";
+}
+
+.fa-person-pregnant {
+  --fa: "\e31e";
+}
+
+.fa-wand-sparkles {
+  --fa: "\f72b";
+}
+
+.fa-ellipsis-vertical {
+  --fa: "\f142";
+}
+
+.fa-ellipsis-v {
+  --fa: "\f142";
+}
+
+.fa-ticket {
+  --fa: "\f145";
+}
+
+.fa-power-off {
+  --fa: "\f011";
+}
+
+.fa-right-long {
+  --fa: "\f30b";
+}
+
+.fa-long-arrow-alt-right {
+  --fa: "\f30b";
+}
+
+.fa-flag-usa {
+  --fa: "\f74d";
+}
+
+.fa-laptop-file {
+  --fa: "\e51d";
+}
+
+.fa-tty {
+  --fa: "\f1e4";
+}
+
+.fa-teletype {
+  --fa: "\f1e4";
+}
+
+.fa-diagram-next {
+  --fa: "\e476";
+}
+
+.fa-person-rifle {
+  --fa: "\e54e";
+}
+
+.fa-house-medical-circle-exclamation {
+  --fa: "\e512";
+}
+
+.fa-closed-captioning {
+  --fa: "\f20a";
+}
+
+.fa-person-hiking {
+  --fa: "\f6ec";
+}
+
+.fa-hiking {
+  --fa: "\f6ec";
+}
+
+.fa-venus-double {
+  --fa: "\f226";
+}
+
+.fa-images {
+  --fa: "\f302";
+}
+
+.fa-calculator {
+  --fa: "\f1ec";
+}
+
+.fa-people-pulling {
+  --fa: "\e535";
+}
+
+.fa-n {
+  --fa: "N";
+}
+
+.fa-cable-car {
+  --fa: "\f7da";
+}
+
+.fa-tram {
+  --fa: "\f7da";
+}
+
+.fa-cloud-rain {
+  --fa: "\f73d";
+}
+
+.fa-building-circle-xmark {
+  --fa: "\e4d4";
+}
+
+.fa-ship {
+  --fa: "\f21a";
+}
+
+.fa-arrows-down-to-line {
+  --fa: "\e4b8";
+}
+
+.fa-download {
+  --fa: "\f019";
+}
+
+.fa-face-grin {
+  --fa: "\f580";
+}
+
+.fa-grin {
+  --fa: "\f580";
+}
+
+.fa-delete-left {
+  --fa: "\f55a";
+}
+
+.fa-backspace {
+  --fa: "\f55a";
+}
+
+.fa-eye-dropper {
+  --fa: "\f1fb";
+}
+
+.fa-eye-dropper-empty {
+  --fa: "\f1fb";
+}
+
+.fa-eyedropper {
+  --fa: "\f1fb";
+}
+
+.fa-file-circle-check {
+  --fa: "\e5a0";
+}
+
+.fa-forward {
+  --fa: "\f04e";
+}
+
+.fa-mobile {
+  --fa: "\f3ce";
+}
+
+.fa-mobile-android {
+  --fa: "\f3ce";
+}
+
+.fa-mobile-phone {
+  --fa: "\f3ce";
+}
+
+.fa-face-meh {
+  --fa: "\f11a";
+}
+
+.fa-meh {
+  --fa: "\f11a";
+}
+
+.fa-align-center {
+  --fa: "\f037";
+}
+
+.fa-book-skull {
+  --fa: "\f6b7";
+}
+
+.fa-book-dead {
+  --fa: "\f6b7";
+}
+
+.fa-id-card {
+  --fa: "\f2c2";
+}
+
+.fa-drivers-license {
+  --fa: "\f2c2";
+}
+
+.fa-outdent {
+  --fa: "\f03b";
+}
+
+.fa-dedent {
+  --fa: "\f03b";
+}
+
+.fa-heart-circle-exclamation {
+  --fa: "\e4fe";
+}
+
+.fa-house {
+  --fa: "\f015";
+}
+
+.fa-home {
+  --fa: "\f015";
+}
+
+.fa-home-alt {
+  --fa: "\f015";
+}
+
+.fa-home-lg-alt {
+  --fa: "\f015";
+}
+
+.fa-calendar-week {
+  --fa: "\f784";
+}
+
+.fa-laptop-medical {
+  --fa: "\f812";
+}
+
+.fa-b {
+  --fa: "B";
+}
+
+.fa-file-medical {
+  --fa: "\f477";
+}
+
+.fa-dice-one {
+  --fa: "\f525";
+}
+
+.fa-kiwi-bird {
+  --fa: "\f535";
+}
+
+.fa-arrow-right-arrow-left {
+  --fa: "\f0ec";
+}
+
+.fa-exchange {
+  --fa: "\f0ec";
+}
+
+.fa-rotate-right {
+  --fa: "\f2f9";
+}
+
+.fa-redo-alt {
+  --fa: "\f2f9";
+}
+
+.fa-rotate-forward {
+  --fa: "\f2f9";
+}
+
+.fa-utensils {
+  --fa: "\f2e7";
+}
+
+.fa-cutlery {
+  --fa: "\f2e7";
+}
+
+.fa-arrow-up-wide-short {
+  --fa: "\f161";
+}
+
+.fa-sort-amount-up {
+  --fa: "\f161";
+}
+
+.fa-mill-sign {
+  --fa: "\e1ed";
+}
+
+.fa-bowl-rice {
+  --fa: "\e2eb";
+}
+
+.fa-skull {
+  --fa: "\f54c";
+}
+
+.fa-tower-broadcast {
+  --fa: "\f519";
+}
+
+.fa-broadcast-tower {
+  --fa: "\f519";
+}
+
+.fa-truck-pickup {
+  --fa: "\f63c";
+}
+
+.fa-up-long {
+  --fa: "\f30c";
+}
+
+.fa-long-arrow-alt-up {
+  --fa: "\f30c";
+}
+
+.fa-stop {
+  --fa: "\f04d";
+}
+
+.fa-code-merge {
+  --fa: "\f387";
+}
+
+.fa-upload {
+  --fa: "\f093";
+}
+
+.fa-hurricane {
+  --fa: "\f751";
+}
+
+.fa-mound {
+  --fa: "\e52d";
+}
+
+.fa-toilet-portable {
+  --fa: "\e583";
+}
+
+.fa-compact-disc {
+  --fa: "\f51f";
+}
+
+.fa-file-arrow-down {
+  --fa: "\f56d";
+}
+
+.fa-file-download {
+  --fa: "\f56d";
+}
+
+.fa-caravan {
+  --fa: "\f8ff";
+}
+
+.fa-shield-cat {
+  --fa: "\e572";
+}
+
+.fa-bolt {
+  --fa: "\f0e7";
+}
+
+.fa-zap {
+  --fa: "\f0e7";
+}
+
+.fa-glass-water {
+  --fa: "\e4f4";
+}
+
+.fa-oil-well {
+  --fa: "\e532";
+}
+
+.fa-vault {
+  --fa: "\e2c5";
+}
+
+.fa-mars {
+  --fa: "\f222";
+}
+
+.fa-toilet {
+  --fa: "\f7d8";
+}
+
+.fa-plane-circle-xmark {
+  --fa: "\e557";
+}
+
+.fa-yen-sign {
+  --fa: "\f157";
+}
+
+.fa-cny {
+  --fa: "\f157";
+}
+
+.fa-jpy {
+  --fa: "\f157";
+}
+
+.fa-rmb {
+  --fa: "\f157";
+}
+
+.fa-yen {
+  --fa: "\f157";
+}
+
+.fa-ruble-sign {
+  --fa: "\f158";
+}
+
+.fa-rouble {
+  --fa: "\f158";
+}
+
+.fa-rub {
+  --fa: "\f158";
+}
+
+.fa-ruble {
+  --fa: "\f158";
+}
+
+.fa-sun {
+  --fa: "\f185";
+}
+
+.fa-guitar {
+  --fa: "\f7a6";
+}
+
+.fa-face-laugh-wink {
+  --fa: "\f59c";
+}
+
+.fa-laugh-wink {
+  --fa: "\f59c";
+}
+
+.fa-horse-head {
+  --fa: "\f7ab";
+}
+
+.fa-bore-hole {
+  --fa: "\e4c3";
+}
+
+.fa-industry {
+  --fa: "\f275";
+}
+
+.fa-circle-down {
+  --fa: "\f358";
+}
+
+.fa-arrow-alt-circle-down {
+  --fa: "\f358";
+}
+
+.fa-arrows-turn-to-dots {
+  --fa: "\e4c1";
+}
+
+.fa-florin-sign {
+  --fa: "\e184";
+}
+
+.fa-arrow-down-short-wide {
+  --fa: "\f884";
+}
+
+.fa-sort-amount-desc {
+  --fa: "\f884";
+}
+
+.fa-sort-amount-down-alt {
+  --fa: "\f884";
+}
+
+.fa-less-than {
+  --fa: "\<";
+}
+
+.fa-angle-down {
+  --fa: "\f107";
+}
+
+.fa-car-tunnel {
+  --fa: "\e4de";
+}
+
+.fa-head-side-cough {
+  --fa: "\e061";
+}
+
+.fa-grip-lines {
+  --fa: "\f7a4";
+}
+
+.fa-thumbs-down {
+  --fa: "\f165";
+}
+
+.fa-user-lock {
+  --fa: "\f502";
+}
+
+.fa-arrow-right-long {
+  --fa: "\f178";
+}
+
+.fa-long-arrow-right {
+  --fa: "\f178";
+}
+
+.fa-anchor-circle-xmark {
+  --fa: "\e4ac";
+}
+
+.fa-ellipsis {
+  --fa: "\f141";
+}
+
+.fa-ellipsis-h {
+  --fa: "\f141";
+}
+
+.fa-chess-pawn {
+  --fa: "\f443";
+}
+
+.fa-kit-medical {
+  --fa: "\f479";
+}
+
+.fa-first-aid {
+  --fa: "\f479";
+}
+
+.fa-person-through-window {
+  --fa: "\e5a9";
+}
+
+.fa-toolbox {
+  --fa: "\f552";
+}
+
+.fa-hands-holding-circle {
+  --fa: "\e4fb";
+}
+
+.fa-bug {
+  --fa: "\f188";
+}
+
+.fa-credit-card {
+  --fa: "\f09d";
+}
+
+.fa-credit-card-alt {
+  --fa: "\f09d";
+}
+
+.fa-car {
+  --fa: "\f1b9";
+}
+
+.fa-automobile {
+  --fa: "\f1b9";
+}
+
+.fa-hand-holding-hand {
+  --fa: "\e4f7";
+}
+
+.fa-book-open-reader {
+  --fa: "\f5da";
+}
+
+.fa-book-reader {
+  --fa: "\f5da";
+}
+
+.fa-mountain-sun {
+  --fa: "\e52f";
+}
+
+.fa-arrows-left-right-to-line {
+  --fa: "\e4ba";
+}
+
+.fa-dice-d20 {
+  --fa: "\f6cf";
+}
+
+.fa-truck-droplet {
+  --fa: "\e58c";
+}
+
+.fa-file-circle-xmark {
+  --fa: "\e5a1";
+}
+
+.fa-temperature-arrow-up {
+  --fa: "\e040";
+}
+
+.fa-temperature-up {
+  --fa: "\e040";
+}
+
+.fa-medal {
+  --fa: "\f5a2";
+}
+
+.fa-bed {
+  --fa: "\f236";
+}
+
+.fa-square-h {
+  --fa: "\f0fd";
+}
+
+.fa-h-square {
+  --fa: "\f0fd";
+}
+
+.fa-podcast {
+  --fa: "\f2ce";
+}
+
+.fa-temperature-full {
+  --fa: "\f2c7";
+}
+
+.fa-temperature-4 {
+  --fa: "\f2c7";
+}
+
+.fa-thermometer-4 {
+  --fa: "\f2c7";
+}
+
+.fa-thermometer-full {
+  --fa: "\f2c7";
+}
+
+.fa-bell {
+  --fa: "\f0f3";
+}
+
+.fa-superscript {
+  --fa: "\f12b";
+}
+
+.fa-plug-circle-xmark {
+  --fa: "\e560";
+}
+
+.fa-star-of-life {
+  --fa: "\f621";
+}
+
+.fa-phone-slash {
+  --fa: "\f3dd";
+}
+
+.fa-paint-roller {
+  --fa: "\f5aa";
+}
+
+.fa-handshake-angle {
+  --fa: "\f4c4";
+}
+
+.fa-hands-helping {
+  --fa: "\f4c4";
+}
+
+.fa-location-dot {
+  --fa: "\f3c5";
+}
+
+.fa-map-marker-alt {
+  --fa: "\f3c5";
+}
+
+.fa-file {
+  --fa: "\f15b";
+}
+
+.fa-greater-than {
+  --fa: "\>";
+}
+
+.fa-person-swimming {
+  --fa: "\f5c4";
+}
+
+.fa-swimmer {
+  --fa: "\f5c4";
+}
+
+.fa-arrow-down {
+  --fa: "\f063";
+}
+
+.fa-droplet {
+  --fa: "\f043";
+}
+
+.fa-tint {
+  --fa: "\f043";
+}
+
+.fa-eraser {
+  --fa: "\f12d";
+}
+
+.fa-earth-americas {
+  --fa: "\f57d";
+}
+
+.fa-earth {
+  --fa: "\f57d";
+}
+
+.fa-earth-america {
+  --fa: "\f57d";
+}
+
+.fa-globe-americas {
+  --fa: "\f57d";
+}
+
+.fa-person-burst {
+  --fa: "\e53b";
+}
+
+.fa-dove {
+  --fa: "\f4ba";
+}
+
+.fa-battery-empty {
+  --fa: "\f244";
+}
+
+.fa-battery-0 {
+  --fa: "\f244";
+}
+
+.fa-socks {
+  --fa: "\f696";
+}
+
+.fa-inbox {
+  --fa: "\f01c";
+}
+
+.fa-section {
+  --fa: "\e447";
+}
+
+.fa-gauge-high {
+  --fa: "\f625";
+}
+
+.fa-tachometer-alt {
+  --fa: "\f625";
+}
+
+.fa-tachometer-alt-fast {
+  --fa: "\f625";
+}
+
+.fa-envelope-open-text {
+  --fa: "\f658";
+}
+
+.fa-hospital {
+  --fa: "\f0f8";
+}
+
+.fa-hospital-alt {
+  --fa: "\f0f8";
+}
+
+.fa-hospital-wide {
+  --fa: "\f0f8";
+}
+
+.fa-wine-bottle {
+  --fa: "\f72f";
+}
+
+.fa-chess-rook {
+  --fa: "\f447";
+}
+
+.fa-bars-staggered {
+  --fa: "\f550";
+}
+
+.fa-reorder {
+  --fa: "\f550";
+}
+
+.fa-stream {
+  --fa: "\f550";
+}
+
+.fa-dharmachakra {
+  --fa: "\f655";
+}
+
+.fa-hotdog {
+  --fa: "\f80f";
+}
+
+.fa-person-walking-with-cane {
+  --fa: "\f29d";
+}
+
+.fa-blind {
+  --fa: "\f29d";
+}
+
+.fa-drum {
+  --fa: "\f569";
+}
+
+.fa-ice-cream {
+  --fa: "\f810";
+}
+
+.fa-heart-circle-bolt {
+  --fa: "\e4fc";
+}
+
+.fa-fax {
+  --fa: "\f1ac";
+}
+
+.fa-paragraph {
+  --fa: "\f1dd";
+}
+
+.fa-check-to-slot {
+  --fa: "\f772";
+}
+
+.fa-vote-yea {
+  --fa: "\f772";
+}
+
+.fa-star-half {
+  --fa: "\f089";
+}
+
+.fa-boxes-stacked {
+  --fa: "\f468";
+}
+
+.fa-boxes {
+  --fa: "\f468";
+}
+
+.fa-boxes-alt {
+  --fa: "\f468";
+}
+
+.fa-link {
+  --fa: "\f0c1";
+}
+
+.fa-chain {
+  --fa: "\f0c1";
+}
+
+.fa-ear-listen {
+  --fa: "\f2a2";
+}
+
+.fa-assistive-listening-systems {
+  --fa: "\f2a2";
+}
+
+.fa-tree-city {
+  --fa: "\e587";
+}
+
+.fa-play {
+  --fa: "\f04b";
+}
+
+.fa-font {
+  --fa: "\f031";
+}
+
+.fa-table-cells-row-lock {
+  --fa: "\e67a";
+}
+
+.fa-rupiah-sign {
+  --fa: "\e23d";
+}
+
+.fa-magnifying-glass {
+  --fa: "\f002";
+}
+
+.fa-search {
+  --fa: "\f002";
+}
+
+.fa-table-tennis-paddle-ball {
+  --fa: "\f45d";
+}
+
+.fa-ping-pong-paddle-ball {
+  --fa: "\f45d";
+}
+
+.fa-table-tennis {
+  --fa: "\f45d";
+}
+
+.fa-person-dots-from-line {
+  --fa: "\f470";
+}
+
+.fa-diagnoses {
+  --fa: "\f470";
+}
+
+.fa-trash-can-arrow-up {
+  --fa: "\f82a";
+}
+
+.fa-trash-restore-alt {
+  --fa: "\f82a";
+}
+
+.fa-naira-sign {
+  --fa: "\e1f6";
+}
+
+.fa-cart-arrow-down {
+  --fa: "\f218";
+}
+
+.fa-walkie-talkie {
+  --fa: "\f8ef";
+}
+
+.fa-file-pen {
+  --fa: "\f31c";
+}
+
+.fa-file-edit {
+  --fa: "\f31c";
+}
+
+.fa-receipt {
+  --fa: "\f543";
+}
+
+.fa-square-pen {
+  --fa: "\f14b";
+}
+
+.fa-pen-square {
+  --fa: "\f14b";
+}
+
+.fa-pencil-square {
+  --fa: "\f14b";
+}
+
+.fa-suitcase-rolling {
+  --fa: "\f5c1";
+}
+
+.fa-person-circle-exclamation {
+  --fa: "\e53f";
+}
+
+.fa-chevron-down {
+  --fa: "\f078";
+}
+
+.fa-battery-full {
+  --fa: "\f240";
+}
+
+.fa-battery {
+  --fa: "\f240";
+}
+
+.fa-battery-5 {
+  --fa: "\f240";
+}
+
+.fa-skull-crossbones {
+  --fa: "\f714";
+}
+
+.fa-code-compare {
+  --fa: "\e13a";
+}
+
+.fa-list-ul {
+  --fa: "\f0ca";
+}
+
+.fa-list-dots {
+  --fa: "\f0ca";
+}
+
+.fa-school-lock {
+  --fa: "\e56f";
+}
+
+.fa-tower-cell {
+  --fa: "\e585";
+}
+
+.fa-down-long {
+  --fa: "\f309";
+}
+
+.fa-long-arrow-alt-down {
+  --fa: "\f309";
+}
+
+.fa-ranking-star {
+  --fa: "\e561";
+}
+
+.fa-chess-king {
+  --fa: "\f43f";
+}
+
+.fa-person-harassing {
+  --fa: "\e549";
+}
+
+.fa-brazilian-real-sign {
+  --fa: "\e46c";
+}
+
+.fa-landmark-dome {
+  --fa: "\f752";
+}
+
+.fa-landmark-alt {
+  --fa: "\f752";
+}
+
+.fa-arrow-up {
+  --fa: "\f062";
+}
+
+.fa-tv {
+  --fa: "\f26c";
+}
+
+.fa-television {
+  --fa: "\f26c";
+}
+
+.fa-tv-alt {
+  --fa: "\f26c";
+}
+
+.fa-shrimp {
+  --fa: "\e448";
+}
+
+.fa-list-check {
+  --fa: "\f0ae";
+}
+
+.fa-tasks {
+  --fa: "\f0ae";
+}
+
+.fa-jug-detergent {
+  --fa: "\e519";
+}
+
+.fa-circle-user {
+  --fa: "\f2bd";
+}
+
+.fa-user-circle {
+  --fa: "\f2bd";
+}
+
+.fa-user-shield {
+  --fa: "\f505";
+}
+
+.fa-wind {
+  --fa: "\f72e";
+}
+
+.fa-car-burst {
+  --fa: "\f5e1";
+}
+
+.fa-car-crash {
+  --fa: "\f5e1";
+}
+
+.fa-y {
+  --fa: "Y";
+}
+
+.fa-person-snowboarding {
+  --fa: "\f7ce";
+}
+
+.fa-snowboarding {
+  --fa: "\f7ce";
+}
+
+.fa-truck-fast {
+  --fa: "\f48b";
+}
+
+.fa-shipping-fast {
+  --fa: "\f48b";
+}
+
+.fa-fish {
+  --fa: "\f578";
+}
+
+.fa-user-graduate {
+  --fa: "\f501";
+}
+
+.fa-circle-half-stroke {
+  --fa: "\f042";
+}
+
+.fa-adjust {
+  --fa: "\f042";
+}
+
+.fa-clapperboard {
+  --fa: "\e131";
+}
+
+.fa-circle-radiation {
+  --fa: "\f7ba";
+}
+
+.fa-radiation-alt {
+  --fa: "\f7ba";
+}
+
+.fa-baseball {
+  --fa: "\f433";
+}
+
+.fa-baseball-ball {
+  --fa: "\f433";
+}
+
+.fa-jet-fighter-up {
+  --fa: "\e518";
+}
+
+.fa-diagram-project {
+  --fa: "\f542";
+}
+
+.fa-project-diagram {
+  --fa: "\f542";
+}
+
+.fa-copy {
+  --fa: "\f0c5";
+}
+
+.fa-volume-xmark {
+  --fa: "\f6a9";
+}
+
+.fa-volume-mute {
+  --fa: "\f6a9";
+}
+
+.fa-volume-times {
+  --fa: "\f6a9";
+}
+
+.fa-hand-sparkles {
+  --fa: "\e05d";
+}
+
+.fa-grip {
+  --fa: "\f58d";
+}
+
+.fa-grip-horizontal {
+  --fa: "\f58d";
+}
+
+.fa-share-from-square {
+  --fa: "\f14d";
+}
+
+.fa-share-square {
+  --fa: "\f14d";
+}
+
+.fa-child-combatant {
+  --fa: "\e4e0";
+}
+
+.fa-child-rifle {
+  --fa: "\e4e0";
+}
+
+.fa-gun {
+  --fa: "\e19b";
+}
+
+.fa-square-phone {
+  --fa: "\f098";
+}
+
+.fa-phone-square {
+  --fa: "\f098";
+}
+
+.fa-plus {
+  --fa: "\+";
+}
+
+.fa-add {
+  --fa: "\+";
+}
+
+.fa-expand {
+  --fa: "\f065";
+}
+
+.fa-computer {
+  --fa: "\e4e5";
+}
+
+.fa-xmark {
+  --fa: "\f00d";
+}
+
+.fa-close {
+  --fa: "\f00d";
+}
+
+.fa-multiply {
+  --fa: "\f00d";
+}
+
+.fa-remove {
+  --fa: "\f00d";
+}
+
+.fa-times {
+  --fa: "\f00d";
+}
+
+.fa-arrows-up-down-left-right {
+  --fa: "\f047";
+}
+
+.fa-arrows {
+  --fa: "\f047";
+}
+
+.fa-chalkboard-user {
+  --fa: "\f51c";
+}
+
+.fa-chalkboard-teacher {
+  --fa: "\f51c";
+}
+
+.fa-peso-sign {
+  --fa: "\e222";
+}
+
+.fa-building-shield {
+  --fa: "\e4d8";
+}
+
+.fa-baby {
+  --fa: "\f77c";
+}
+
+.fa-users-line {
+  --fa: "\e592";
+}
+
+.fa-quote-left {
+  --fa: "\f10d";
+}
+
+.fa-quote-left-alt {
+  --fa: "\f10d";
+}
+
+.fa-tractor {
+  --fa: "\f722";
+}
+
+.fa-trash-arrow-up {
+  --fa: "\f829";
+}
+
+.fa-trash-restore {
+  --fa: "\f829";
+}
+
+.fa-arrow-down-up-lock {
+  --fa: "\e4b0";
+}
+
+.fa-lines-leaning {
+  --fa: "\e51e";
+}
+
+.fa-ruler-combined {
+  --fa: "\f546";
+}
+
+.fa-copyright {
+  --fa: "\f1f9";
+}
+
+.fa-equals {
+  --fa: "\=";
+}
+
+.fa-blender {
+  --fa: "\f517";
+}
+
+.fa-teeth {
+  --fa: "\f62e";
+}
+
+.fa-shekel-sign {
+  --fa: "\f20b";
+}
+
+.fa-ils {
+  --fa: "\f20b";
+}
+
+.fa-shekel {
+  --fa: "\f20b";
+}
+
+.fa-sheqel {
+  --fa: "\f20b";
+}
+
+.fa-sheqel-sign {
+  --fa: "\f20b";
+}
+
+.fa-map {
+  --fa: "\f279";
+}
+
+.fa-rocket {
+  --fa: "\f135";
+}
+
+.fa-photo-film {
+  --fa: "\f87c";
+}
+
+.fa-photo-video {
+  --fa: "\f87c";
+}
+
+.fa-folder-minus {
+  --fa: "\f65d";
+}
+
+.fa-hexagon-nodes-bolt {
+  --fa: "\e69a";
+}
+
+.fa-store {
+  --fa: "\f54e";
+}
+
+.fa-arrow-trend-up {
+  --fa: "\e098";
+}
+
+.fa-plug-circle-minus {
+  --fa: "\e55e";
+}
+
+.fa-sign-hanging {
+  --fa: "\f4d9";
+}
+
+.fa-sign {
+  --fa: "\f4d9";
+}
+
+.fa-bezier-curve {
+  --fa: "\f55b";
+}
+
+.fa-bell-slash {
+  --fa: "\f1f6";
+}
+
+.fa-tablet {
+  --fa: "\f3fb";
+}
+
+.fa-tablet-android {
+  --fa: "\f3fb";
+}
+
+.fa-school-flag {
+  --fa: "\e56e";
+}
+
+.fa-fill {
+  --fa: "\f575";
+}
+
+.fa-angle-up {
+  --fa: "\f106";
+}
+
+.fa-drumstick-bite {
+  --fa: "\f6d7";
+}
+
+.fa-holly-berry {
+  --fa: "\f7aa";
+}
+
+.fa-chevron-left {
+  --fa: "\f053";
+}
+
+.fa-bacteria {
+  --fa: "\e059";
+}
+
+.fa-hand-lizard {
+  --fa: "\f258";
+}
+
+.fa-notdef {
+  --fa: "\e1fe";
+}
+
+.fa-disease {
+  --fa: "\f7fa";
+}
+
+.fa-briefcase-medical {
+  --fa: "\f469";
+}
+
+.fa-genderless {
+  --fa: "\f22d";
+}
+
+.fa-chevron-right {
+  --fa: "\f054";
+}
+
+.fa-retweet {
+  --fa: "\f079";
+}
+
+.fa-car-rear {
+  --fa: "\f5de";
+}
+
+.fa-car-alt {
+  --fa: "\f5de";
+}
+
+.fa-pump-soap {
+  --fa: "\e06b";
+}
+
+.fa-video-slash {
+  --fa: "\f4e2";
+}
+
+.fa-battery-quarter {
+  --fa: "\f243";
+}
+
+.fa-battery-2 {
+  --fa: "\f243";
+}
+
+.fa-radio {
+  --fa: "\f8d7";
+}
+
+.fa-baby-carriage {
+  --fa: "\f77d";
+}
+
+.fa-carriage-baby {
+  --fa: "\f77d";
+}
+
+.fa-traffic-light {
+  --fa: "\f637";
+}
+
+.fa-thermometer {
+  --fa: "\f491";
+}
+
+.fa-vr-cardboard {
+  --fa: "\f729";
+}
+
+.fa-hand-middle-finger {
+  --fa: "\f806";
+}
+
+.fa-percent {
+  --fa: "\%";
+}
+
+.fa-percentage {
+  --fa: "\%";
+}
+
+.fa-truck-moving {
+  --fa: "\f4df";
+}
+
+.fa-glass-water-droplet {
+  --fa: "\e4f5";
+}
+
+.fa-display {
+  --fa: "\e163";
+}
+
+.fa-face-smile {
+  --fa: "\f118";
+}
+
+.fa-smile {
+  --fa: "\f118";
+}
+
+.fa-thumbtack {
+  --fa: "\f08d";
+}
+
+.fa-thumb-tack {
+  --fa: "\f08d";
+}
+
+.fa-trophy {
+  --fa: "\f091";
+}
+
+.fa-person-praying {
+  --fa: "\f683";
+}
+
+.fa-pray {
+  --fa: "\f683";
+}
+
+.fa-hammer {
+  --fa: "\f6e3";
+}
+
+.fa-hand-peace {
+  --fa: "\f25b";
+}
+
+.fa-rotate {
+  --fa: "\f2f1";
+}
+
+.fa-sync-alt {
+  --fa: "\f2f1";
+}
+
+.fa-spinner {
+  --fa: "\f110";
+}
+
+.fa-robot {
+  --fa: "\f544";
+}
+
+.fa-peace {
+  --fa: "\f67c";
+}
+
+.fa-gears {
+  --fa: "\f085";
+}
+
+.fa-cogs {
+  --fa: "\f085";
+}
+
+.fa-warehouse {
+  --fa: "\f494";
+}
+
+.fa-arrow-up-right-dots {
+  --fa: "\e4b7";
+}
+
+.fa-splotch {
+  --fa: "\f5bc";
+}
+
+.fa-face-grin-hearts {
+  --fa: "\f584";
+}
+
+.fa-grin-hearts {
+  --fa: "\f584";
+}
+
+.fa-dice-four {
+  --fa: "\f524";
+}
+
+.fa-sim-card {
+  --fa: "\f7c4";
+}
+
+.fa-transgender {
+  --fa: "\f225";
+}
+
+.fa-transgender-alt {
+  --fa: "\f225";
+}
+
+.fa-mercury {
+  --fa: "\f223";
+}
+
+.fa-arrow-turn-down {
+  --fa: "\f149";
+}
+
+.fa-level-down {
+  --fa: "\f149";
+}
+
+.fa-person-falling-burst {
+  --fa: "\e547";
+}
+
+.fa-award {
+  --fa: "\f559";
+}
+
+.fa-ticket-simple {
+  --fa: "\f3ff";
+}
+
+.fa-ticket-alt {
+  --fa: "\f3ff";
+}
+
+.fa-building {
+  --fa: "\f1ad";
+}
+
+.fa-angles-left {
+  --fa: "\f100";
+}
+
+.fa-angle-double-left {
+  --fa: "\f100";
+}
+
+.fa-qrcode {
+  --fa: "\f029";
+}
+
+.fa-clock-rotate-left {
+  --fa: "\f1da";
+}
+
+.fa-history {
+  --fa: "\f1da";
+}
+
+.fa-face-grin-beam-sweat {
+  --fa: "\f583";
+}
+
+.fa-grin-beam-sweat {
+  --fa: "\f583";
+}
+
+.fa-file-export {
+  --fa: "\f56e";
+}
+
+.fa-arrow-right-from-file {
+  --fa: "\f56e";
+}
+
+.fa-shield {
+  --fa: "\f132";
+}
+
+.fa-shield-blank {
+  --fa: "\f132";
+}
+
+.fa-arrow-up-short-wide {
+  --fa: "\f885";
+}
+
+.fa-sort-amount-up-alt {
+  --fa: "\f885";
+}
+
+.fa-comment-nodes {
+  --fa: "\e696";
+}
+
+.fa-house-medical {
+  --fa: "\e3b2";
+}
+
+.fa-golf-ball-tee {
+  --fa: "\f450";
+}
+
+.fa-golf-ball {
+  --fa: "\f450";
+}
+
+.fa-circle-chevron-left {
+  --fa: "\f137";
+}
+
+.fa-chevron-circle-left {
+  --fa: "\f137";
+}
+
+.fa-house-chimney-window {
+  --fa: "\e00d";
+}
+
+.fa-pen-nib {
+  --fa: "\f5ad";
+}
+
+.fa-tent-arrow-turn-left {
+  --fa: "\e580";
+}
+
+.fa-tents {
+  --fa: "\e582";
+}
+
+.fa-wand-magic {
+  --fa: "\f0d0";
+}
+
+.fa-magic {
+  --fa: "\f0d0";
+}
+
+.fa-dog {
+  --fa: "\f6d3";
+}
+
+.fa-carrot {
+  --fa: "\f787";
+}
+
+.fa-moon {
+  --fa: "\f186";
+}
+
+.fa-wine-glass-empty {
+  --fa: "\f5ce";
+}
+
+.fa-wine-glass-alt {
+  --fa: "\f5ce";
+}
+
+.fa-cheese {
+  --fa: "\f7ef";
+}
+
+.fa-yin-yang {
+  --fa: "\f6ad";
+}
+
+.fa-music {
+  --fa: "\f001";
+}
+
+.fa-code-commit {
+  --fa: "\f386";
+}
+
+.fa-temperature-low {
+  --fa: "\f76b";
+}
+
+.fa-person-biking {
+  --fa: "\f84a";
+}
+
+.fa-biking {
+  --fa: "\f84a";
+}
+
+.fa-broom {
+  --fa: "\f51a";
+}
+
+.fa-shield-heart {
+  --fa: "\e574";
+}
+
+.fa-gopuram {
+  --fa: "\f664";
+}
+
+.fa-earth-oceania {
+  --fa: "\e47b";
+}
+
+.fa-globe-oceania {
+  --fa: "\e47b";
+}
+
+.fa-square-xmark {
+  --fa: "\f2d3";
+}
+
+.fa-times-square {
+  --fa: "\f2d3";
+}
+
+.fa-xmark-square {
+  --fa: "\f2d3";
+}
+
+.fa-hashtag {
+  --fa: "\#";
+}
+
+.fa-up-right-and-down-left-from-center {
+  --fa: "\f424";
+}
+
+.fa-expand-alt {
+  --fa: "\f424";
+}
+
+.fa-oil-can {
+  --fa: "\f613";
+}
+
+.fa-t {
+  --fa: "T";
+}
+
+.fa-hippo {
+  --fa: "\f6ed";
+}
+
+.fa-chart-column {
+  --fa: "\e0e3";
+}
+
+.fa-infinity {
+  --fa: "\f534";
+}
+
+.fa-vial-circle-check {
+  --fa: "\e596";
+}
+
+.fa-person-arrow-down-to-line {
+  --fa: "\e538";
+}
+
+.fa-voicemail {
+  --fa: "\f897";
+}
+
+.fa-fan {
+  --fa: "\f863";
+}
+
+.fa-person-walking-luggage {
+  --fa: "\e554";
+}
+
+.fa-up-down {
+  --fa: "\f338";
+}
+
+.fa-arrows-alt-v {
+  --fa: "\f338";
+}
+
+.fa-cloud-moon-rain {
+  --fa: "\f73c";
+}
+
+.fa-calendar {
+  --fa: "\f133";
+}
+
+.fa-trailer {
+  --fa: "\e041";
+}
+
+.fa-bahai {
+  --fa: "\f666";
+}
+
+.fa-haykal {
+  --fa: "\f666";
+}
+
+.fa-sd-card {
+  --fa: "\f7c2";
+}
+
+.fa-dragon {
+  --fa: "\f6d5";
+}
+
+.fa-shoe-prints {
+  --fa: "\f54b";
+}
+
+.fa-circle-plus {
+  --fa: "\f055";
+}
+
+.fa-plus-circle {
+  --fa: "\f055";
+}
+
+.fa-face-grin-tongue-wink {
+  --fa: "\f58b";
+}
+
+.fa-grin-tongue-wink {
+  --fa: "\f58b";
+}
+
+.fa-hand-holding {
+  --fa: "\f4bd";
+}
+
+.fa-plug-circle-exclamation {
+  --fa: "\e55d";
+}
+
+.fa-link-slash {
+  --fa: "\f127";
+}
+
+.fa-chain-broken {
+  --fa: "\f127";
+}
+
+.fa-chain-slash {
+  --fa: "\f127";
+}
+
+.fa-unlink {
+  --fa: "\f127";
+}
+
+.fa-clone {
+  --fa: "\f24d";
+}
+
+.fa-person-walking-arrow-loop-left {
+  --fa: "\e551";
+}
+
+.fa-arrow-up-z-a {
+  --fa: "\f882";
+}
+
+.fa-sort-alpha-up-alt {
+  --fa: "\f882";
+}
+
+.fa-fire-flame-curved {
+  --fa: "\f7e4";
+}
+
+.fa-fire-alt {
+  --fa: "\f7e4";
+}
+
+.fa-tornado {
+  --fa: "\f76f";
+}
+
+.fa-file-circle-plus {
+  --fa: "\e494";
+}
+
+.fa-book-quran {
+  --fa: "\f687";
+}
+
+.fa-quran {
+  --fa: "\f687";
+}
+
+.fa-anchor {
+  --fa: "\f13d";
+}
+
+.fa-border-all {
+  --fa: "\f84c";
+}
+
+.fa-face-angry {
+  --fa: "\f556";
+}
+
+.fa-angry {
+  --fa: "\f556";
+}
+
+.fa-cookie-bite {
+  --fa: "\f564";
+}
+
+.fa-arrow-trend-down {
+  --fa: "\e097";
+}
+
+.fa-rss {
+  --fa: "\f09e";
+}
+
+.fa-feed {
+  --fa: "\f09e";
+}
+
+.fa-draw-polygon {
+  --fa: "\f5ee";
+}
+
+.fa-scale-balanced {
+  --fa: "\f24e";
+}
+
+.fa-balance-scale {
+  --fa: "\f24e";
+}
+
+.fa-gauge-simple-high {
+  --fa: "\f62a";
+}
+
+.fa-tachometer {
+  --fa: "\f62a";
+}
+
+.fa-tachometer-fast {
+  --fa: "\f62a";
+}
+
+.fa-shower {
+  --fa: "\f2cc";
+}
+
+.fa-desktop {
+  --fa: "\f390";
+}
+
+.fa-desktop-alt {
+  --fa: "\f390";
+}
+
+.fa-m {
+  --fa: "M";
+}
+
+.fa-table-list {
+  --fa: "\f00b";
+}
+
+.fa-th-list {
+  --fa: "\f00b";
+}
+
+.fa-comment-sms {
+  --fa: "\f7cd";
+}
+
+.fa-sms {
+  --fa: "\f7cd";
+}
+
+.fa-book {
+  --fa: "\f02d";
+}
+
+.fa-user-plus {
+  --fa: "\f234";
+}
+
+.fa-check {
+  --fa: "\f00c";
+}
+
+.fa-battery-three-quarters {
+  --fa: "\f241";
+}
+
+.fa-battery-4 {
+  --fa: "\f241";
+}
+
+.fa-house-circle-check {
+  --fa: "\e509";
+}
+
+.fa-angle-left {
+  --fa: "\f104";
+}
+
+.fa-diagram-successor {
+  --fa: "\e47a";
+}
+
+.fa-truck-arrow-right {
+  --fa: "\e58b";
+}
+
+.fa-arrows-split-up-and-left {
+  --fa: "\e4bc";
+}
+
+.fa-hand-fist {
+  --fa: "\f6de";
+}
+
+.fa-fist-raised {
+  --fa: "\f6de";
+}
+
+.fa-cloud-moon {
+  --fa: "\f6c3";
+}
+
+.fa-briefcase {
+  --fa: "\f0b1";
+}
+
+.fa-person-falling {
+  --fa: "\e546";
+}
+
+.fa-image-portrait {
+  --fa: "\f3e0";
+}
+
+.fa-portrait {
+  --fa: "\f3e0";
+}
+
+.fa-user-tag {
+  --fa: "\f507";
+}
+
+.fa-rug {
+  --fa: "\e569";
+}
+
+.fa-earth-europe {
+  --fa: "\f7a2";
+}
+
+.fa-globe-europe {
+  --fa: "\f7a2";
+}
+
+.fa-cart-flatbed-suitcase {
+  --fa: "\f59d";
+}
+
+.fa-luggage-cart {
+  --fa: "\f59d";
+}
+
+.fa-rectangle-xmark {
+  --fa: "\f410";
+}
+
+.fa-rectangle-times {
+  --fa: "\f410";
+}
+
+.fa-times-rectangle {
+  --fa: "\f410";
+}
+
+.fa-window-close {
+  --fa: "\f410";
+}
+
+.fa-baht-sign {
+  --fa: "\e0ac";
+}
+
+.fa-book-open {
+  --fa: "\f518";
+}
+
+.fa-book-journal-whills {
+  --fa: "\f66a";
+}
+
+.fa-journal-whills {
+  --fa: "\f66a";
+}
+
+.fa-handcuffs {
+  --fa: "\e4f8";
+}
+
+.fa-triangle-exclamation {
+  --fa: "\f071";
+}
+
+.fa-exclamation-triangle {
+  --fa: "\f071";
+}
+
+.fa-warning {
+  --fa: "\f071";
+}
+
+.fa-database {
+  --fa: "\f1c0";
+}
+
+.fa-share {
+  --fa: "\f064";
+}
+
+.fa-mail-forward {
+  --fa: "\f064";
+}
+
+.fa-bottle-droplet {
+  --fa: "\e4c4";
+}
+
+.fa-mask-face {
+  --fa: "\e1d7";
+}
+
+.fa-hill-rockslide {
+  --fa: "\e508";
+}
+
+.fa-right-left {
+  --fa: "\f362";
+}
+
+.fa-exchange-alt {
+  --fa: "\f362";
+}
+
+.fa-paper-plane {
+  --fa: "\f1d8";
+}
+
+.fa-road-circle-exclamation {
+  --fa: "\e565";
+}
+
+.fa-dungeon {
+  --fa: "\f6d9";
+}
+
+.fa-align-right {
+  --fa: "\f038";
+}
+
+.fa-money-bill-1-wave {
+  --fa: "\f53b";
+}
+
+.fa-money-bill-wave-alt {
+  --fa: "\f53b";
+}
+
+.fa-life-ring {
+  --fa: "\f1cd";
+}
+
+.fa-hands {
+  --fa: "\f2a7";
+}
+
+.fa-sign-language {
+  --fa: "\f2a7";
+}
+
+.fa-signing {
+  --fa: "\f2a7";
+}
+
+.fa-calendar-day {
+  --fa: "\f783";
+}
+
+.fa-water-ladder {
+  --fa: "\f5c5";
+}
+
+.fa-ladder-water {
+  --fa: "\f5c5";
+}
+
+.fa-swimming-pool {
+  --fa: "\f5c5";
+}
+
+.fa-arrows-up-down {
+  --fa: "\f07d";
+}
+
+.fa-arrows-v {
+  --fa: "\f07d";
+}
+
+.fa-face-grimace {
+  --fa: "\f57f";
+}
+
+.fa-grimace {
+  --fa: "\f57f";
+}
+
+.fa-wheelchair-move {
+  --fa: "\e2ce";
+}
+
+.fa-wheelchair-alt {
+  --fa: "\e2ce";
+}
+
+.fa-turn-down {
+  --fa: "\f3be";
+}
+
+.fa-level-down-alt {
+  --fa: "\f3be";
+}
+
+.fa-person-walking-arrow-right {
+  --fa: "\e552";
+}
+
+.fa-square-envelope {
+  --fa: "\f199";
+}
+
+.fa-envelope-square {
+  --fa: "\f199";
+}
+
+.fa-dice {
+  --fa: "\f522";
+}
+
+.fa-bowling-ball {
+  --fa: "\f436";
+}
+
+.fa-brain {
+  --fa: "\f5dc";
+}
+
+.fa-bandage {
+  --fa: "\f462";
+}
+
+.fa-band-aid {
+  --fa: "\f462";
+}
+
+.fa-calendar-minus {
+  --fa: "\f272";
+}
+
+.fa-circle-xmark {
+  --fa: "\f057";
+}
+
+.fa-times-circle {
+  --fa: "\f057";
+}
+
+.fa-xmark-circle {
+  --fa: "\f057";
+}
+
+.fa-gifts {
+  --fa: "\f79c";
+}
+
+.fa-hotel {
+  --fa: "\f594";
+}
+
+.fa-earth-asia {
+  --fa: "\f57e";
+}
+
+.fa-globe-asia {
+  --fa: "\f57e";
+}
+
+.fa-id-card-clip {
+  --fa: "\f47f";
+}
+
+.fa-id-card-alt {
+  --fa: "\f47f";
+}
+
+.fa-magnifying-glass-plus {
+  --fa: "\f00e";
+}
+
+.fa-search-plus {
+  --fa: "\f00e";
+}
+
+.fa-thumbs-up {
+  --fa: "\f164";
+}
+
+.fa-user-clock {
+  --fa: "\f4fd";
+}
+
+.fa-hand-dots {
+  --fa: "\f461";
+}
+
+.fa-allergies {
+  --fa: "\f461";
+}
+
+.fa-file-invoice {
+  --fa: "\f570";
+}
+
+.fa-window-minimize {
+  --fa: "\f2d1";
+}
+
+.fa-mug-saucer {
+  --fa: "\f0f4";
+}
+
+.fa-coffee {
+  --fa: "\f0f4";
+}
+
+.fa-brush {
+  --fa: "\f55d";
+}
+
+.fa-file-half-dashed {
+  --fa: "\e698";
+}
+
+.fa-mask {
+  --fa: "\f6fa";
+}
+
+.fa-magnifying-glass-minus {
+  --fa: "\f010";
+}
+
+.fa-search-minus {
+  --fa: "\f010";
+}
+
+.fa-ruler-vertical {
+  --fa: "\f548";
+}
+
+.fa-user-large {
+  --fa: "\f406";
+}
+
+.fa-user-alt {
+  --fa: "\f406";
+}
+
+.fa-train-tram {
+  --fa: "\e5b4";
+}
+
+.fa-user-nurse {
+  --fa: "\f82f";
+}
+
+.fa-syringe {
+  --fa: "\f48e";
+}
+
+.fa-cloud-sun {
+  --fa: "\f6c4";
+}
+
+.fa-stopwatch-20 {
+  --fa: "\e06f";
+}
+
+.fa-square-full {
+  --fa: "\f45c";
+}
+
+.fa-magnet {
+  --fa: "\f076";
+}
+
+.fa-jar {
+  --fa: "\e516";
+}
+
+.fa-note-sticky {
+  --fa: "\f249";
+}
+
+.fa-sticky-note {
+  --fa: "\f249";
+}
+
+.fa-bug-slash {
+  --fa: "\e490";
+}
+
+.fa-arrow-up-from-water-pump {
+  --fa: "\e4b6";
+}
+
+.fa-bone {
+  --fa: "\f5d7";
+}
+
+.fa-table-cells-row-unlock {
+  --fa: "\e691";
+}
+
+.fa-user-injured {
+  --fa: "\f728";
+}
+
+.fa-face-sad-tear {
+  --fa: "\f5b4";
+}
+
+.fa-sad-tear {
+  --fa: "\f5b4";
+}
+
+.fa-plane {
+  --fa: "\f072";
+}
+
+.fa-tent-arrows-down {
+  --fa: "\e581";
+}
+
+.fa-exclamation {
+  --fa: "\!";
+}
+
+.fa-arrows-spin {
+  --fa: "\e4bb";
+}
+
+.fa-print {
+  --fa: "\f02f";
+}
+
+.fa-turkish-lira-sign {
+  --fa: "\e2bb";
+}
+
+.fa-try {
+  --fa: "\e2bb";
+}
+
+.fa-turkish-lira {
+  --fa: "\e2bb";
+}
+
+.fa-dollar-sign {
+  --fa: "\$";
+}
+
+.fa-dollar {
+  --fa: "\$";
+}
+
+.fa-usd {
+  --fa: "\$";
+}
+
+.fa-x {
+  --fa: "X";
+}
+
+.fa-magnifying-glass-dollar {
+  --fa: "\f688";
+}
+
+.fa-search-dollar {
+  --fa: "\f688";
+}
+
+.fa-users-gear {
+  --fa: "\f509";
+}
+
+.fa-users-cog {
+  --fa: "\f509";
+}
+
+.fa-person-military-pointing {
+  --fa: "\e54a";
+}
+
+.fa-building-columns {
+  --fa: "\f19c";
+}
+
+.fa-bank {
+  --fa: "\f19c";
+}
+
+.fa-institution {
+  --fa: "\f19c";
+}
+
+.fa-museum {
+  --fa: "\f19c";
+}
+
+.fa-university {
+  --fa: "\f19c";
+}
+
+.fa-umbrella {
+  --fa: "\f0e9";
+}
+
+.fa-trowel {
+  --fa: "\e589";
+}
+
+.fa-d {
+  --fa: "D";
+}
+
+.fa-stapler {
+  --fa: "\e5af";
+}
+
+.fa-masks-theater {
+  --fa: "\f630";
+}
+
+.fa-theater-masks {
+  --fa: "\f630";
+}
+
+.fa-kip-sign {
+  --fa: "\e1c4";
+}
+
+.fa-hand-point-left {
+  --fa: "\f0a5";
+}
+
+.fa-handshake-simple {
+  --fa: "\f4c6";
+}
+
+.fa-handshake-alt {
+  --fa: "\f4c6";
+}
+
+.fa-jet-fighter {
+  --fa: "\f0fb";
+}
+
+.fa-fighter-jet {
+  --fa: "\f0fb";
+}
+
+.fa-square-share-nodes {
+  --fa: "\f1e1";
+}
+
+.fa-share-alt-square {
+  --fa: "\f1e1";
+}
+
+.fa-barcode {
+  --fa: "\f02a";
+}
+
+.fa-plus-minus {
+  --fa: "\e43c";
+}
+
+.fa-video {
+  --fa: "\f03d";
+}
+
+.fa-video-camera {
+  --fa: "\f03d";
+}
+
+.fa-graduation-cap {
+  --fa: "\f19d";
+}
+
+.fa-mortar-board {
+  --fa: "\f19d";
+}
+
+.fa-hand-holding-medical {
+  --fa: "\e05c";
+}
+
+.fa-person-circle-check {
+  --fa: "\e53e";
+}
+
+.fa-turn-up {
+  --fa: "\f3bf";
+}
+
+.fa-level-up-alt {
+  --fa: "\f3bf";
+}
+
+.sr-only,
+.fa-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.sr-only-focusable:not(:focus),
+.fa-sr-only-focusable:not(:focus) {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+/*!
+ * Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+ * Copyright 2024 Fonticons, Inc.
+ */
+:root, :host {
+  --fa-style-family-classic: "Font Awesome 6 Free";
+  --fa-font-solid: normal 900 1em/1 "Font Awesome 6 Free";
+}
+
+@font-face {
+  font-family: "Font Awesome 6 Free";
+  font-style: normal;
+  font-weight: 900;
+  font-display: block;
+  src: url("../fontawesome/webfonts/fa-solid-900.woff2") format("woff2"), url("../fontawesome/webfonts/fa-solid-900.ttf") format("truetype");
+}
+.fas,
+.fa-solid {
+  font-weight: 900;
+}
+
+/*!
+ * Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+ * Copyright 2024 Fonticons, Inc.
+ */
+:root, :host {
+  --fa-style-family-brands: "Font Awesome 6 Brands";
+  --fa-font-brands: normal 400 1em/1 "Font Awesome 6 Brands";
+}
+
+@font-face {
+  font-family: "Font Awesome 6 Brands";
+  font-style: normal;
+  font-weight: 400;
+  font-display: block;
+  src: url("../fontawesome/webfonts/fa-brands-400.woff2") format("woff2"), url("../fontawesome/webfonts/fa-brands-400.ttf") format("truetype");
+}
+.fab,
+.fa-brands {
+  font-weight: 400;
+}
+
+.fa-monero {
+  --fa: "\f3d0";
+}
+
+.fa-hooli {
+  --fa: "\f427";
+}
+
+.fa-yelp {
+  --fa: "\f1e9";
+}
+
+.fa-cc-visa {
+  --fa: "\f1f0";
+}
+
+.fa-lastfm {
+  --fa: "\f202";
+}
+
+.fa-shopware {
+  --fa: "\f5b5";
+}
+
+.fa-creative-commons-nc {
+  --fa: "\f4e8";
+}
+
+.fa-aws {
+  --fa: "\f375";
+}
+
+.fa-redhat {
+  --fa: "\f7bc";
+}
+
+.fa-yoast {
+  --fa: "\f2b1";
+}
+
+.fa-cloudflare {
+  --fa: "\e07d";
+}
+
+.fa-ups {
+  --fa: "\f7e0";
+}
+
+.fa-pixiv {
+  --fa: "\e640";
+}
+
+.fa-wpexplorer {
+  --fa: "\f2de";
+}
+
+.fa-dyalog {
+  --fa: "\f399";
+}
+
+.fa-bity {
+  --fa: "\f37a";
+}
+
+.fa-stackpath {
+  --fa: "\f842";
+}
+
+.fa-buysellads {
+  --fa: "\f20d";
+}
+
+.fa-first-order {
+  --fa: "\f2b0";
+}
+
+.fa-modx {
+  --fa: "\f285";
+}
+
+.fa-guilded {
+  --fa: "\e07e";
+}
+
+.fa-vnv {
+  --fa: "\f40b";
+}
+
+.fa-square-js {
+  --fa: "\f3b9";
+}
+
+.fa-js-square {
+  --fa: "\f3b9";
+}
+
+.fa-microsoft {
+  --fa: "\f3ca";
+}
+
+.fa-qq {
+  --fa: "\f1d6";
+}
+
+.fa-orcid {
+  --fa: "\f8d2";
+}
+
+.fa-java {
+  --fa: "\f4e4";
+}
+
+.fa-invision {
+  --fa: "\f7b0";
+}
+
+.fa-creative-commons-pd-alt {
+  --fa: "\f4ed";
+}
+
+.fa-centercode {
+  --fa: "\f380";
+}
+
+.fa-glide-g {
+  --fa: "\f2a6";
+}
+
+.fa-drupal {
+  --fa: "\f1a9";
+}
+
+.fa-jxl {
+  --fa: "\e67b";
+}
+
+.fa-dart-lang {
+  --fa: "\e693";
+}
+
+.fa-hire-a-helper {
+  --fa: "\f3b0";
+}
+
+.fa-creative-commons-by {
+  --fa: "\f4e7";
+}
+
+.fa-unity {
+  --fa: "\e049";
+}
+
+.fa-whmcs {
+  --fa: "\f40d";
+}
+
+.fa-rocketchat {
+  --fa: "\f3e8";
+}
+
+.fa-vk {
+  --fa: "\f189";
+}
+
+.fa-untappd {
+  --fa: "\f405";
+}
+
+.fa-mailchimp {
+  --fa: "\f59e";
+}
+
+.fa-css3-alt {
+  --fa: "\f38b";
+}
+
+.fa-square-reddit {
+  --fa: "\f1a2";
+}
+
+.fa-reddit-square {
+  --fa: "\f1a2";
+}
+
+.fa-vimeo-v {
+  --fa: "\f27d";
+}
+
+.fa-contao {
+  --fa: "\f26d";
+}
+
+.fa-square-font-awesome {
+  --fa: "\e5ad";
+}
+
+.fa-deskpro {
+  --fa: "\f38f";
+}
+
+.fa-brave {
+  --fa: "\e63c";
+}
+
+.fa-sistrix {
+  --fa: "\f3ee";
+}
+
+.fa-square-instagram {
+  --fa: "\e055";
+}
+
+.fa-instagram-square {
+  --fa: "\e055";
+}
+
+.fa-battle-net {
+  --fa: "\f835";
+}
+
+.fa-the-red-yeti {
+  --fa: "\f69d";
+}
+
+.fa-square-hacker-news {
+  --fa: "\f3af";
+}
+
+.fa-hacker-news-square {
+  --fa: "\f3af";
+}
+
+.fa-edge {
+  --fa: "\f282";
+}
+
+.fa-threads {
+  --fa: "\e618";
+}
+
+.fa-napster {
+  --fa: "\f3d2";
+}
+
+.fa-square-snapchat {
+  --fa: "\f2ad";
+}
+
+.fa-snapchat-square {
+  --fa: "\f2ad";
+}
+
+.fa-google-plus-g {
+  --fa: "\f0d5";
+}
+
+.fa-artstation {
+  --fa: "\f77a";
+}
+
+.fa-markdown {
+  --fa: "\f60f";
+}
+
+.fa-sourcetree {
+  --fa: "\f7d3";
+}
+
+.fa-google-plus {
+  --fa: "\f2b3";
+}
+
+.fa-diaspora {
+  --fa: "\f791";
+}
+
+.fa-foursquare {
+  --fa: "\f180";
+}
+
+.fa-stack-overflow {
+  --fa: "\f16c";
+}
+
+.fa-github-alt {
+  --fa: "\f113";
+}
+
+.fa-phoenix-squadron {
+  --fa: "\f511";
+}
+
+.fa-pagelines {
+  --fa: "\f18c";
+}
+
+.fa-algolia {
+  --fa: "\f36c";
+}
+
+.fa-red-river {
+  --fa: "\f3e3";
+}
+
+.fa-creative-commons-sa {
+  --fa: "\f4ef";
+}
+
+.fa-safari {
+  --fa: "\f267";
+}
+
+.fa-google {
+  --fa: "\f1a0";
+}
+
+.fa-square-font-awesome-stroke {
+  --fa: "\f35c";
+}
+
+.fa-font-awesome-alt {
+  --fa: "\f35c";
+}
+
+.fa-atlassian {
+  --fa: "\f77b";
+}
+
+.fa-linkedin-in {
+  --fa: "\f0e1";
+}
+
+.fa-digital-ocean {
+  --fa: "\f391";
+}
+
+.fa-nimblr {
+  --fa: "\f5a8";
+}
+
+.fa-chromecast {
+  --fa: "\f838";
+}
+
+.fa-evernote {
+  --fa: "\f839";
+}
+
+.fa-hacker-news {
+  --fa: "\f1d4";
+}
+
+.fa-creative-commons-sampling {
+  --fa: "\f4f0";
+}
+
+.fa-adversal {
+  --fa: "\f36a";
+}
+
+.fa-creative-commons {
+  --fa: "\f25e";
+}
+
+.fa-watchman-monitoring {
+  --fa: "\e087";
+}
+
+.fa-fonticons {
+  --fa: "\f280";
+}
+
+.fa-weixin {
+  --fa: "\f1d7";
+}
+
+.fa-shirtsinbulk {
+  --fa: "\f214";
+}
+
+.fa-codepen {
+  --fa: "\f1cb";
+}
+
+.fa-git-alt {
+  --fa: "\f841";
+}
+
+.fa-lyft {
+  --fa: "\f3c3";
+}
+
+.fa-rev {
+  --fa: "\f5b2";
+}
+
+.fa-windows {
+  --fa: "\f17a";
+}
+
+.fa-wizards-of-the-coast {
+  --fa: "\f730";
+}
+
+.fa-square-viadeo {
+  --fa: "\f2aa";
+}
+
+.fa-viadeo-square {
+  --fa: "\f2aa";
+}
+
+.fa-meetup {
+  --fa: "\f2e0";
+}
+
+.fa-centos {
+  --fa: "\f789";
+}
+
+.fa-adn {
+  --fa: "\f170";
+}
+
+.fa-cloudsmith {
+  --fa: "\f384";
+}
+
+.fa-opensuse {
+  --fa: "\e62b";
+}
+
+.fa-pied-piper-alt {
+  --fa: "\f1a8";
+}
+
+.fa-square-dribbble {
+  --fa: "\f397";
+}
+
+.fa-dribbble-square {
+  --fa: "\f397";
+}
+
+.fa-codiepie {
+  --fa: "\f284";
+}
+
+.fa-node {
+  --fa: "\f419";
+}
+
+.fa-mix {
+  --fa: "\f3cb";
+}
+
+.fa-steam {
+  --fa: "\f1b6";
+}
+
+.fa-cc-apple-pay {
+  --fa: "\f416";
+}
+
+.fa-scribd {
+  --fa: "\f28a";
+}
+
+.fa-debian {
+  --fa: "\e60b";
+}
+
+.fa-openid {
+  --fa: "\f19b";
+}
+
+.fa-instalod {
+  --fa: "\e081";
+}
+
+.fa-files-pinwheel {
+  --fa: "\e69f";
+}
+
+.fa-expeditedssl {
+  --fa: "\f23e";
+}
+
+.fa-sellcast {
+  --fa: "\f2da";
+}
+
+.fa-square-twitter {
+  --fa: "\f081";
+}
+
+.fa-twitter-square {
+  --fa: "\f081";
+}
+
+.fa-r-project {
+  --fa: "\f4f7";
+}
+
+.fa-delicious {
+  --fa: "\f1a5";
+}
+
+.fa-freebsd {
+  --fa: "\f3a4";
+}
+
+.fa-vuejs {
+  --fa: "\f41f";
+}
+
+.fa-accusoft {
+  --fa: "\f369";
+}
+
+.fa-ioxhost {
+  --fa: "\f208";
+}
+
+.fa-fonticons-fi {
+  --fa: "\f3a2";
+}
+
+.fa-app-store {
+  --fa: "\f36f";
+}
+
+.fa-cc-mastercard {
+  --fa: "\f1f1";
+}
+
+.fa-itunes-note {
+  --fa: "\f3b5";
+}
+
+.fa-golang {
+  --fa: "\e40f";
+}
+
+.fa-kickstarter {
+  --fa: "\f3bb";
+}
+
+.fa-square-kickstarter {
+  --fa: "\f3bb";
+}
+
+.fa-grav {
+  --fa: "\f2d6";
+}
+
+.fa-weibo {
+  --fa: "\f18a";
+}
+
+.fa-uncharted {
+  --fa: "\e084";
+}
+
+.fa-firstdraft {
+  --fa: "\f3a1";
+}
+
+.fa-square-youtube {
+  --fa: "\f431";
+}
+
+.fa-youtube-square {
+  --fa: "\f431";
+}
+
+.fa-wikipedia-w {
+  --fa: "\f266";
+}
+
+.fa-wpressr {
+  --fa: "\f3e4";
+}
+
+.fa-rendact {
+  --fa: "\f3e4";
+}
+
+.fa-angellist {
+  --fa: "\f209";
+}
+
+.fa-galactic-republic {
+  --fa: "\f50c";
+}
+
+.fa-nfc-directional {
+  --fa: "\e530";
+}
+
+.fa-skype {
+  --fa: "\f17e";
+}
+
+.fa-joget {
+  --fa: "\f3b7";
+}
+
+.fa-fedora {
+  --fa: "\f798";
+}
+
+.fa-stripe-s {
+  --fa: "\f42a";
+}
+
+.fa-meta {
+  --fa: "\e49b";
+}
+
+.fa-laravel {
+  --fa: "\f3bd";
+}
+
+.fa-hotjar {
+  --fa: "\f3b1";
+}
+
+.fa-bluetooth-b {
+  --fa: "\f294";
+}
+
+.fa-square-letterboxd {
+  --fa: "\e62e";
+}
+
+.fa-sticker-mule {
+  --fa: "\f3f7";
+}
+
+.fa-creative-commons-zero {
+  --fa: "\f4f3";
+}
+
+.fa-hips {
+  --fa: "\f452";
+}
+
+.fa-css {
+  --fa: "\e6a2";
+}
+
+.fa-behance {
+  --fa: "\f1b4";
+}
+
+.fa-reddit {
+  --fa: "\f1a1";
+}
+
+.fa-discord {
+  --fa: "\f392";
+}
+
+.fa-chrome {
+  --fa: "\f268";
+}
+
+.fa-app-store-ios {
+  --fa: "\f370";
+}
+
+.fa-cc-discover {
+  --fa: "\f1f2";
+}
+
+.fa-wpbeginner {
+  --fa: "\f297";
+}
+
+.fa-confluence {
+  --fa: "\f78d";
+}
+
+.fa-shoelace {
+  --fa: "\e60c";
+}
+
+.fa-mdb {
+  --fa: "\f8ca";
+}
+
+.fa-dochub {
+  --fa: "\f394";
+}
+
+.fa-accessible-icon {
+  --fa: "\f368";
+}
+
+.fa-ebay {
+  --fa: "\f4f4";
+}
+
+.fa-amazon {
+  --fa: "\f270";
+}
+
+.fa-unsplash {
+  --fa: "\e07c";
+}
+
+.fa-yarn {
+  --fa: "\f7e3";
+}
+
+.fa-square-steam {
+  --fa: "\f1b7";
+}
+
+.fa-steam-square {
+  --fa: "\f1b7";
+}
+
+.fa-500px {
+  --fa: "\f26e";
+}
+
+.fa-square-vimeo {
+  --fa: "\f194";
+}
+
+.fa-vimeo-square {
+  --fa: "\f194";
+}
+
+.fa-asymmetrik {
+  --fa: "\f372";
+}
+
+.fa-font-awesome {
+  --fa: "\f2b4";
+}
+
+.fa-font-awesome-flag {
+  --fa: "\f2b4";
+}
+
+.fa-font-awesome-logo-full {
+  --fa: "\f2b4";
+}
+
+.fa-gratipay {
+  --fa: "\f184";
+}
+
+.fa-apple {
+  --fa: "\f179";
+}
+
+.fa-hive {
+  --fa: "\e07f";
+}
+
+.fa-gitkraken {
+  --fa: "\f3a6";
+}
+
+.fa-keybase {
+  --fa: "\f4f5";
+}
+
+.fa-apple-pay {
+  --fa: "\f415";
+}
+
+.fa-padlet {
+  --fa: "\e4a0";
+}
+
+.fa-amazon-pay {
+  --fa: "\f42c";
+}
+
+.fa-square-github {
+  --fa: "\f092";
+}
+
+.fa-github-square {
+  --fa: "\f092";
+}
+
+.fa-stumbleupon {
+  --fa: "\f1a4";
+}
+
+.fa-fedex {
+  --fa: "\f797";
+}
+
+.fa-phoenix-framework {
+  --fa: "\f3dc";
+}
+
+.fa-shopify {
+  --fa: "\e057";
+}
+
+.fa-neos {
+  --fa: "\f612";
+}
+
+.fa-square-threads {
+  --fa: "\e619";
+}
+
+.fa-hackerrank {
+  --fa: "\f5f7";
+}
+
+.fa-researchgate {
+  --fa: "\f4f8";
+}
+
+.fa-swift {
+  --fa: "\f8e1";
+}
+
+.fa-angular {
+  --fa: "\f420";
+}
+
+.fa-speakap {
+  --fa: "\f3f3";
+}
+
+.fa-angrycreative {
+  --fa: "\f36e";
+}
+
+.fa-y-combinator {
+  --fa: "\f23b";
+}
+
+.fa-empire {
+  --fa: "\f1d1";
+}
+
+.fa-envira {
+  --fa: "\f299";
+}
+
+.fa-google-scholar {
+  --fa: "\e63b";
+}
+
+.fa-square-gitlab {
+  --fa: "\e5ae";
+}
+
+.fa-gitlab-square {
+  --fa: "\e5ae";
+}
+
+.fa-studiovinari {
+  --fa: "\f3f8";
+}
+
+.fa-pied-piper {
+  --fa: "\f2ae";
+}
+
+.fa-wordpress {
+  --fa: "\f19a";
+}
+
+.fa-product-hunt {
+  --fa: "\f288";
+}
+
+.fa-firefox {
+  --fa: "\f269";
+}
+
+.fa-linode {
+  --fa: "\f2b8";
+}
+
+.fa-goodreads {
+  --fa: "\f3a8";
+}
+
+.fa-square-odnoklassniki {
+  --fa: "\f264";
+}
+
+.fa-odnoklassniki-square {
+  --fa: "\f264";
+}
+
+.fa-jsfiddle {
+  --fa: "\f1cc";
+}
+
+.fa-sith {
+  --fa: "\f512";
+}
+
+.fa-themeisle {
+  --fa: "\f2b2";
+}
+
+.fa-page4 {
+  --fa: "\f3d7";
+}
+
+.fa-hashnode {
+  --fa: "\e499";
+}
+
+.fa-react {
+  --fa: "\f41b";
+}
+
+.fa-cc-paypal {
+  --fa: "\f1f4";
+}
+
+.fa-squarespace {
+  --fa: "\f5be";
+}
+
+.fa-cc-stripe {
+  --fa: "\f1f5";
+}
+
+.fa-creative-commons-share {
+  --fa: "\f4f2";
+}
+
+.fa-bitcoin {
+  --fa: "\f379";
+}
+
+.fa-keycdn {
+  --fa: "\f3ba";
+}
+
+.fa-opera {
+  --fa: "\f26a";
+}
+
+.fa-itch-io {
+  --fa: "\f83a";
+}
+
+.fa-umbraco {
+  --fa: "\f8e8";
+}
+
+.fa-galactic-senate {
+  --fa: "\f50d";
+}
+
+.fa-ubuntu {
+  --fa: "\f7df";
+}
+
+.fa-draft2digital {
+  --fa: "\f396";
+}
+
+.fa-stripe {
+  --fa: "\f429";
+}
+
+.fa-houzz {
+  --fa: "\f27c";
+}
+
+.fa-gg {
+  --fa: "\f260";
+}
+
+.fa-dhl {
+  --fa: "\f790";
+}
+
+.fa-square-pinterest {
+  --fa: "\f0d3";
+}
+
+.fa-pinterest-square {
+  --fa: "\f0d3";
+}
+
+.fa-xing {
+  --fa: "\f168";
+}
+
+.fa-blackberry {
+  --fa: "\f37b";
+}
+
+.fa-creative-commons-pd {
+  --fa: "\f4ec";
+}
+
+.fa-playstation {
+  --fa: "\f3df";
+}
+
+.fa-quinscape {
+  --fa: "\f459";
+}
+
+.fa-less {
+  --fa: "\f41d";
+}
+
+.fa-blogger-b {
+  --fa: "\f37d";
+}
+
+.fa-opencart {
+  --fa: "\f23d";
+}
+
+.fa-vine {
+  --fa: "\f1ca";
+}
+
+.fa-signal-messenger {
+  --fa: "\e663";
+}
+
+.fa-paypal {
+  --fa: "\f1ed";
+}
+
+.fa-gitlab {
+  --fa: "\f296";
+}
+
+.fa-typo3 {
+  --fa: "\f42b";
+}
+
+.fa-reddit-alien {
+  --fa: "\f281";
+}
+
+.fa-yahoo {
+  --fa: "\f19e";
+}
+
+.fa-dailymotion {
+  --fa: "\e052";
+}
+
+.fa-affiliatetheme {
+  --fa: "\f36b";
+}
+
+.fa-pied-piper-pp {
+  --fa: "\f1a7";
+}
+
+.fa-bootstrap {
+  --fa: "\f836";
+}
+
+.fa-odnoklassniki {
+  --fa: "\f263";
+}
+
+.fa-nfc-symbol {
+  --fa: "\e531";
+}
+
+.fa-mintbit {
+  --fa: "\e62f";
+}
+
+.fa-ethereum {
+  --fa: "\f42e";
+}
+
+.fa-speaker-deck {
+  --fa: "\f83c";
+}
+
+.fa-creative-commons-nc-eu {
+  --fa: "\f4e9";
+}
+
+.fa-patreon {
+  --fa: "\f3d9";
+}
+
+.fa-avianex {
+  --fa: "\f374";
+}
+
+.fa-ello {
+  --fa: "\f5f1";
+}
+
+.fa-gofore {
+  --fa: "\f3a7";
+}
+
+.fa-bimobject {
+  --fa: "\f378";
+}
+
+.fa-brave-reverse {
+  --fa: "\e63d";
+}
+
+.fa-facebook-f {
+  --fa: "\f39e";
+}
+
+.fa-square-google-plus {
+  --fa: "\f0d4";
+}
+
+.fa-google-plus-square {
+  --fa: "\f0d4";
+}
+
+.fa-web-awesome {
+  --fa: "\e682";
+}
+
+.fa-mandalorian {
+  --fa: "\f50f";
+}
+
+.fa-first-order-alt {
+  --fa: "\f50a";
+}
+
+.fa-osi {
+  --fa: "\f41a";
+}
+
+.fa-google-wallet {
+  --fa: "\f1ee";
+}
+
+.fa-d-and-d-beyond {
+  --fa: "\f6ca";
+}
+
+.fa-periscope {
+  --fa: "\f3da";
+}
+
+.fa-fulcrum {
+  --fa: "\f50b";
+}
+
+.fa-cloudscale {
+  --fa: "\f383";
+}
+
+.fa-forumbee {
+  --fa: "\f211";
+}
+
+.fa-mizuni {
+  --fa: "\f3cc";
+}
+
+.fa-schlix {
+  --fa: "\f3ea";
+}
+
+.fa-square-xing {
+  --fa: "\f169";
+}
+
+.fa-xing-square {
+  --fa: "\f169";
+}
+
+.fa-bandcamp {
+  --fa: "\f2d5";
+}
+
+.fa-wpforms {
+  --fa: "\f298";
+}
+
+.fa-cloudversify {
+  --fa: "\f385";
+}
+
+.fa-usps {
+  --fa: "\f7e1";
+}
+
+.fa-megaport {
+  --fa: "\f5a3";
+}
+
+.fa-magento {
+  --fa: "\f3c4";
+}
+
+.fa-spotify {
+  --fa: "\f1bc";
+}
+
+.fa-optin-monster {
+  --fa: "\f23c";
+}
+
+.fa-fly {
+  --fa: "\f417";
+}
+
+.fa-square-bluesky {
+  --fa: "\e6a3";
+}
+
+.fa-aviato {
+  --fa: "\f421";
+}
+
+.fa-itunes {
+  --fa: "\f3b4";
+}
+
+.fa-cuttlefish {
+  --fa: "\f38c";
+}
+
+.fa-blogger {
+  --fa: "\f37c";
+}
+
+.fa-flickr {
+  --fa: "\f16e";
+}
+
+.fa-viber {
+  --fa: "\f409";
+}
+
+.fa-soundcloud {
+  --fa: "\f1be";
+}
+
+.fa-digg {
+  --fa: "\f1a6";
+}
+
+.fa-tencent-weibo {
+  --fa: "\f1d5";
+}
+
+.fa-letterboxd {
+  --fa: "\e62d";
+}
+
+.fa-symfony {
+  --fa: "\f83d";
+}
+
+.fa-maxcdn {
+  --fa: "\f136";
+}
+
+.fa-etsy {
+  --fa: "\f2d7";
+}
+
+.fa-facebook-messenger {
+  --fa: "\f39f";
+}
+
+.fa-audible {
+  --fa: "\f373";
+}
+
+.fa-think-peaks {
+  --fa: "\f731";
+}
+
+.fa-bilibili {
+  --fa: "\e3d9";
+}
+
+.fa-erlang {
+  --fa: "\f39d";
+}
+
+.fa-x-twitter {
+  --fa: "\e61b";
+}
+
+.fa-cotton-bureau {
+  --fa: "\f89e";
+}
+
+.fa-dashcube {
+  --fa: "\f210";
+}
+
+.fa-42-group {
+  --fa: "\e080";
+}
+
+.fa-innosoft {
+  --fa: "\e080";
+}
+
+.fa-stack-exchange {
+  --fa: "\f18d";
+}
+
+.fa-elementor {
+  --fa: "\f430";
+}
+
+.fa-square-pied-piper {
+  --fa: "\e01e";
+}
+
+.fa-pied-piper-square {
+  --fa: "\e01e";
+}
+
+.fa-creative-commons-nd {
+  --fa: "\f4eb";
+}
+
+.fa-palfed {
+  --fa: "\f3d8";
+}
+
+.fa-superpowers {
+  --fa: "\f2dd";
+}
+
+.fa-resolving {
+  --fa: "\f3e7";
+}
+
+.fa-xbox {
+  --fa: "\f412";
+}
+
+.fa-square-web-awesome-stroke {
+  --fa: "\e684";
+}
+
+.fa-searchengin {
+  --fa: "\f3eb";
+}
+
+.fa-tiktok {
+  --fa: "\e07b";
+}
+
+.fa-square-facebook {
+  --fa: "\f082";
+}
+
+.fa-facebook-square {
+  --fa: "\f082";
+}
+
+.fa-renren {
+  --fa: "\f18b";
+}
+
+.fa-linux {
+  --fa: "\f17c";
+}
+
+.fa-glide {
+  --fa: "\f2a5";
+}
+
+.fa-linkedin {
+  --fa: "\f08c";
+}
+
+.fa-hubspot {
+  --fa: "\f3b2";
+}
+
+.fa-deploydog {
+  --fa: "\f38e";
+}
+
+.fa-twitch {
+  --fa: "\f1e8";
+}
+
+.fa-flutter {
+  --fa: "\e694";
+}
+
+.fa-ravelry {
+  --fa: "\f2d9";
+}
+
+.fa-mixer {
+  --fa: "\e056";
+}
+
+.fa-square-lastfm {
+  --fa: "\f203";
+}
+
+.fa-lastfm-square {
+  --fa: "\f203";
+}
+
+.fa-vimeo {
+  --fa: "\f40a";
+}
+
+.fa-mendeley {
+  --fa: "\f7b3";
+}
+
+.fa-uniregistry {
+  --fa: "\f404";
+}
+
+.fa-figma {
+  --fa: "\f799";
+}
+
+.fa-creative-commons-remix {
+  --fa: "\f4ee";
+}
+
+.fa-cc-amazon-pay {
+  --fa: "\f42d";
+}
+
+.fa-dropbox {
+  --fa: "\f16b";
+}
+
+.fa-instagram {
+  --fa: "\f16d";
+}
+
+.fa-cmplid {
+  --fa: "\e360";
+}
+
+.fa-upwork {
+  --fa: "\e641";
+}
+
+.fa-facebook {
+  --fa: "\f09a";
+}
+
+.fa-gripfire {
+  --fa: "\f3ac";
+}
+
+.fa-jedi-order {
+  --fa: "\f50e";
+}
+
+.fa-uikit {
+  --fa: "\f403";
+}
+
+.fa-fort-awesome-alt {
+  --fa: "\f3a3";
+}
+
+.fa-phabricator {
+  --fa: "\f3db";
+}
+
+.fa-ussunnah {
+  --fa: "\f407";
+}
+
+.fa-earlybirds {
+  --fa: "\f39a";
+}
+
+.fa-trade-federation {
+  --fa: "\f513";
+}
+
+.fa-autoprefixer {
+  --fa: "\f41c";
+}
+
+.fa-whatsapp {
+  --fa: "\f232";
+}
+
+.fa-square-upwork {
+  --fa: "\e67c";
+}
+
+.fa-slideshare {
+  --fa: "\f1e7";
+}
+
+.fa-google-play {
+  --fa: "\f3ab";
+}
+
+.fa-viadeo {
+  --fa: "\f2a9";
+}
+
+.fa-line {
+  --fa: "\f3c0";
+}
+
+.fa-google-drive {
+  --fa: "\f3aa";
+}
+
+.fa-servicestack {
+  --fa: "\f3ec";
+}
+
+.fa-simplybuilt {
+  --fa: "\f215";
+}
+
+.fa-bitbucket {
+  --fa: "\f171";
+}
+
+.fa-imdb {
+  --fa: "\f2d8";
+}
+
+.fa-deezer {
+  --fa: "\e077";
+}
+
+.fa-raspberry-pi {
+  --fa: "\f7bb";
+}
+
+.fa-jira {
+  --fa: "\f7b1";
+}
+
+.fa-docker {
+  --fa: "\f395";
+}
+
+.fa-screenpal {
+  --fa: "\e570";
+}
+
+.fa-bluetooth {
+  --fa: "\f293";
+}
+
+.fa-gitter {
+  --fa: "\f426";
+}
+
+.fa-d-and-d {
+  --fa: "\f38d";
+}
+
+.fa-microblog {
+  --fa: "\e01a";
+}
+
+.fa-cc-diners-club {
+  --fa: "\f24c";
+}
+
+.fa-gg-circle {
+  --fa: "\f261";
+}
+
+.fa-pied-piper-hat {
+  --fa: "\f4e5";
+}
+
+.fa-kickstarter-k {
+  --fa: "\f3bc";
+}
+
+.fa-yandex {
+  --fa: "\f413";
+}
+
+.fa-readme {
+  --fa: "\f4d5";
+}
+
+.fa-html5 {
+  --fa: "\f13b";
+}
+
+.fa-sellsy {
+  --fa: "\f213";
+}
+
+.fa-square-web-awesome {
+  --fa: "\e683";
+}
+
+.fa-sass {
+  --fa: "\f41e";
+}
+
+.fa-wirsindhandwerk {
+  --fa: "\e2d0";
+}
+
+.fa-wsh {
+  --fa: "\e2d0";
+}
+
+.fa-buromobelexperte {
+  --fa: "\f37f";
+}
+
+.fa-salesforce {
+  --fa: "\f83b";
+}
+
+.fa-octopus-deploy {
+  --fa: "\e082";
+}
+
+.fa-medapps {
+  --fa: "\f3c6";
+}
+
+.fa-ns8 {
+  --fa: "\f3d5";
+}
+
+.fa-pinterest-p {
+  --fa: "\f231";
+}
+
+.fa-apper {
+  --fa: "\f371";
+}
+
+.fa-fort-awesome {
+  --fa: "\f286";
+}
+
+.fa-waze {
+  --fa: "\f83f";
+}
+
+.fa-bluesky {
+  --fa: "\e671";
+}
+
+.fa-cc-jcb {
+  --fa: "\f24b";
+}
+
+.fa-snapchat {
+  --fa: "\f2ab";
+}
+
+.fa-snapchat-ghost {
+  --fa: "\f2ab";
+}
+
+.fa-fantasy-flight-games {
+  --fa: "\f6dc";
+}
+
+.fa-rust {
+  --fa: "\e07a";
+}
+
+.fa-wix {
+  --fa: "\f5cf";
+}
+
+.fa-square-behance {
+  --fa: "\f1b5";
+}
+
+.fa-behance-square {
+  --fa: "\f1b5";
+}
+
+.fa-supple {
+  --fa: "\f3f9";
+}
+
+.fa-webflow {
+  --fa: "\e65c";
+}
+
+.fa-rebel {
+  --fa: "\f1d0";
+}
+
+.fa-css3 {
+  --fa: "\f13c";
+}
+
+.fa-staylinked {
+  --fa: "\f3f5";
+}
+
+.fa-kaggle {
+  --fa: "\f5fa";
+}
+
+.fa-space-awesome {
+  --fa: "\e5ac";
+}
+
+.fa-deviantart {
+  --fa: "\f1bd";
+}
+
+.fa-cpanel {
+  --fa: "\f388";
+}
+
+.fa-goodreads-g {
+  --fa: "\f3a9";
+}
+
+.fa-square-git {
+  --fa: "\f1d2";
+}
+
+.fa-git-square {
+  --fa: "\f1d2";
+}
+
+.fa-square-tumblr {
+  --fa: "\f174";
+}
+
+.fa-tumblr-square {
+  --fa: "\f174";
+}
+
+.fa-trello {
+  --fa: "\f181";
+}
+
+.fa-creative-commons-nc-jp {
+  --fa: "\f4ea";
+}
+
+.fa-get-pocket {
+  --fa: "\f265";
+}
+
+.fa-perbyte {
+  --fa: "\e083";
+}
+
+.fa-grunt {
+  --fa: "\f3ad";
+}
+
+.fa-weebly {
+  --fa: "\f5cc";
+}
+
+.fa-connectdevelop {
+  --fa: "\f20e";
+}
+
+.fa-leanpub {
+  --fa: "\f212";
+}
+
+.fa-black-tie {
+  --fa: "\f27e";
+}
+
+.fa-themeco {
+  --fa: "\f5c6";
+}
+
+.fa-python {
+  --fa: "\f3e2";
+}
+
+.fa-android {
+  --fa: "\f17b";
+}
+
+.fa-bots {
+  --fa: "\e340";
+}
+
+.fa-free-code-camp {
+  --fa: "\f2c5";
+}
+
+.fa-hornbill {
+  --fa: "\f592";
+}
+
+.fa-js {
+  --fa: "\f3b8";
+}
+
+.fa-ideal {
+  --fa: "\e013";
+}
+
+.fa-git {
+  --fa: "\f1d3";
+}
+
+.fa-dev {
+  --fa: "\f6cc";
+}
+
+.fa-sketch {
+  --fa: "\f7c6";
+}
+
+.fa-yandex-international {
+  --fa: "\f414";
+}
+
+.fa-cc-amex {
+  --fa: "\f1f3";
+}
+
+.fa-uber {
+  --fa: "\f402";
+}
+
+.fa-github {
+  --fa: "\f09b";
+}
+
+.fa-php {
+  --fa: "\f457";
+}
+
+.fa-alipay {
+  --fa: "\f642";
+}
+
+.fa-youtube {
+  --fa: "\f167";
+}
+
+.fa-skyatlas {
+  --fa: "\f216";
+}
+
+.fa-firefox-browser {
+  --fa: "\e007";
+}
+
+.fa-replyd {
+  --fa: "\f3e6";
+}
+
+.fa-suse {
+  --fa: "\f7d6";
+}
+
+.fa-jenkins {
+  --fa: "\f3b6";
+}
+
+.fa-twitter {
+  --fa: "\f099";
+}
+
+.fa-rockrms {
+  --fa: "\f3e9";
+}
+
+.fa-pinterest {
+  --fa: "\f0d2";
+}
+
+.fa-buffer {
+  --fa: "\f837";
+}
+
+.fa-npm {
+  --fa: "\f3d4";
+}
+
+.fa-yammer {
+  --fa: "\f840";
+}
+
+.fa-btc {
+  --fa: "\f15a";
+}
+
+.fa-dribbble {
+  --fa: "\f17d";
+}
+
+.fa-stumbleupon-circle {
+  --fa: "\f1a3";
+}
+
+.fa-internet-explorer {
+  --fa: "\f26b";
+}
+
+.fa-stubber {
+  --fa: "\e5c7";
+}
+
+.fa-telegram {
+  --fa: "\f2c6";
+}
+
+.fa-telegram-plane {
+  --fa: "\f2c6";
+}
+
+.fa-old-republic {
+  --fa: "\f510";
+}
+
+.fa-odysee {
+  --fa: "\e5c6";
+}
+
+.fa-square-whatsapp {
+  --fa: "\f40c";
+}
+
+.fa-whatsapp-square {
+  --fa: "\f40c";
+}
+
+.fa-node-js {
+  --fa: "\f3d3";
+}
+
+.fa-edge-legacy {
+  --fa: "\e078";
+}
+
+.fa-slack {
+  --fa: "\f198";
+}
+
+.fa-slack-hash {
+  --fa: "\f198";
+}
+
+.fa-medrt {
+  --fa: "\f3c8";
+}
+
+.fa-usb {
+  --fa: "\f287";
+}
+
+.fa-tumblr {
+  --fa: "\f173";
+}
+
+.fa-vaadin {
+  --fa: "\f408";
+}
+
+.fa-quora {
+  --fa: "\f2c4";
+}
+
+.fa-square-x-twitter {
+  --fa: "\e61a";
+}
+
+.fa-reacteurope {
+  --fa: "\f75d";
+}
+
+.fa-medium {
+  --fa: "\f23a";
+}
+
+.fa-medium-m {
+  --fa: "\f23a";
+}
+
+.fa-amilia {
+  --fa: "\f36d";
+}
+
+.fa-mixcloud {
+  --fa: "\f289";
+}
+
+.fa-flipboard {
+  --fa: "\f44d";
+}
+
+.fa-viacoin {
+  --fa: "\f237";
+}
+
+.fa-critical-role {
+  --fa: "\f6c9";
+}
+
+.fa-sitrox {
+  --fa: "\e44a";
+}
+
+.fa-discourse {
+  --fa: "\f393";
+}
+
+.fa-joomla {
+  --fa: "\f1aa";
+}
+
+.fa-mastodon {
+  --fa: "\f4f6";
+}
+
+.fa-airbnb {
+  --fa: "\f834";
+}
+
+.fa-wolf-pack-battalion {
+  --fa: "\f514";
+}
+
+.fa-buy-n-large {
+  --fa: "\f8a6";
+}
+
+.fa-gulp {
+  --fa: "\f3ae";
+}
+
+.fa-creative-commons-sampling-plus {
+  --fa: "\f4f1";
+}
+
+.fa-strava {
+  --fa: "\f428";
+}
+
+.fa-ember {
+  --fa: "\f423";
+}
+
+.fa-canadian-maple-leaf {
+  --fa: "\f785";
+}
+
+.fa-teamspeak {
+  --fa: "\f4f9";
+}
+
+.fa-pushed {
+  --fa: "\f3e1";
+}
+
+.fa-wordpress-simple {
+  --fa: "\f411";
+}
+
+.fa-nutritionix {
+  --fa: "\f3d6";
+}
+
+.fa-wodu {
+  --fa: "\e088";
+}
+
+.fa-google-pay {
+  --fa: "\e079";
+}
+
+.fa-intercom {
+  --fa: "\f7af";
+}
+
+.fa-zhihu {
+  --fa: "\f63f";
+}
+
+.fa-korvue {
+  --fa: "\f42f";
+}
+
+.fa-pix {
+  --fa: "\e43a";
+}
+
+.fa-steam-symbol {
+  --fa: "\f3f6";
 }
 
 *, *::before, *::after {
-    margin: 0;
-    padding: 0;
+  margin: 0;
+  padding: 0;
 }
 
 html, body {
-    font-family: "Nunito", sans-serif !important;
+  font-family: "Nunito", sans-serif !important;
 }
 
-.wrapper {
-    width: 100%;
-    height: 100%;
+.navbar {
+  height: 90px;
+  background-color: #0A1929;
+  font-size: 1rem;
+  font-weight: 700;
+}
+.navbar a:focus-visible {
+  outline: -webkit-focus-ring-color auto 1px;
+}
+.navbar .navbar-dark .navbar-toggler {
+  border: 1px solid rgb(222, 226, 230);
+}
+.navbar .navbar-dark .navbar-toggler-icon {
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30"><path stroke="rgba("222, 226, 230, 1") stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" d="M4 7h22M4 15h22M4 23h22"/></svg>');
+}
+.navbar .navbar-collapse {
+  background-color: #0A1929;
+}
+.navbar .navbar-collapse .navbar-nav {
+  border-bottom: #dee2e6;
+}
+.navbar .navbar-collapse .navbar-nav li {
+  padding: 1rem;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+.navbar .navbar-collapse .navbar-nav li a:hover {
+  border-bottom: 2px solid #dee2e6;
 }
 
-.spinner-wrapper {
-    background-color: var(--primary);
+@keyframes slide-in {
+  from {
+    margin-left: 100%;
+    opacity: 0;
+  }
+  to {
+    margin-left: 0%;
     opacity: 1;
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 9999;
-    transition: opacity 0.7s;
-
-    .spinner-border {
-        width: 60px;
-        height: 60px;
-    }
+  }
+}
+.spinner-wrapper {
+  background-color: #0A1929;
+  opacity: 1;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 9999;
+  transition: opacity 0.7s;
+}
+.spinner-wrapper .spinner-border {
+  width: 60px;
+  height: 60px;
 }
 
 .spinner-wrapper[style*="opacity: 0"] {
-    pointer-events: none;
+  pointer-events: none;
 }
 
-/*******************
-* NAVBAR STYLES 
-******************/
-.navbar {
-    height: 90px;
-    background-color: var(--primary);
-    font-size: 1rem;
-    font-weight: 700;
-
-    a:focus-visible {
-        outline: -webkit-focus-ring-color auto 1px;
-    }
-
-    .navbar-dark .navbar-toggler {
-        border: 1px solid rgba(222, 226, 230, 1);
-    }
-
-    .navbar-dark .navbar-toggler-icon {
-        background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30"><path stroke="rgba("222, 226, 230, 1") stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" d="M4 7h22M4 15h22M4 23h22"/></svg>');
-    }
-
-    .navbar-collapse {
-        background-color: var(--primary);
-
-        .navbar-nav {
-            border-bottom: var(--gray-300);
-
-            li { 
-                padding: 1rem;
-                width: 100%;
-                display: flex;
-                justify-content: center;
-
-                a:hover {
-                    border-bottom: 2px solid var(--gray-300);
-                }
-            }
-        }
-    }
-}
-
-/*******************
-* MAIN CONTENT STYLES
-******************/
 #main-home {
-    background-color: var(--primary);
-    color: var(--gray-300);
-
-    .hero-section {
-        .hero-content {
-
-            .hero-text {
-                flex: 1;
-                min-width: 0;
-                flex-basis: 40%;
-            }
-
-            .hero-img {
-                flex: 1;
-                width: auto;
-                min-width: 0;
-                min-height: 600px;
-                flex-basis: 60%;
-
-                .cloud-shape {
-                    height: 427px;
-                    object-fit: fill;
-                    clip-path: path('M 90 240 A 30 30 90 0 1 180 150 A 30 30 90 0 1 330 180 A 30 30 90 0 1 390 210 A 22.5 22.5 90 0 1 420 240 A 9 9 90 0 1 420 270 A 37.5 30 0 0 1 360 300 A 45 30 0 0 1 270 300 A 60 30 0 0 1 120 300 A 30 30 90 0 1 90 240');
-                }
-            }
-        }
-    }
-
-    @media screen and (min-width: 991px) {
-        .hero-section {
-            .hero-content {
-
-                .hero-text {
-                    flex-basis: 50%;
-                }
-
-                .hero-img {
-                    flex-basis: 50%;
-                    min-height: 600px;
-                }
-            }
-        }
-    }
-
-    #about {
-
-        header+section>section {
-            padding: 0 1.5rem;
-
-            h3 {
-                padding-top: 1.5rem;
-            }
-
-            h3,
-            p {
-                text-align: left
-            }
-        }
-    }
+  background-color: #0A1929;
+  color: #dee2e6;
+}
+#main-home .hero-section .hero-content .hero-text {
+  flex: 1;
+  min-width: 0;
+  flex-basis: 40%;
+}
+#main-home .hero-section .hero-content .hero-img {
+  flex: 1;
+  width: auto;
+  min-width: 0;
+  min-height: 600px;
+  flex-basis: 60%;
+}
+#main-home .hero-section .hero-content .hero-img .cloud-shape {
+  height: 427px;
+  object-fit: fill;
+  clip-path: path("M 90 240 A 30 30 90 0 1 180 150 A 30 30 90 0 1 330 180 A 30 30 90 0 1 390 210 A 22.5 22.5 90 0 1 420 240 A 9 9 90 0 1 420 270 A 37.5 30 0 0 1 360 300 A 45 30 0 0 1 270 300 A 60 30 0 0 1 120 300 A 30 30 90 0 1 90 240");
+}
+@media (min-width: 992px) {
+  #main-home .hero-section .hero-content .hero-text {
+    flex-basis: 50%;
+  }
+  #main-home .hero-section .hero-content .hero-img {
+    flex-basis: 50%;
+    min-height: 600px;
+  }
+}
+#main-home #about header + section > section {
+  padding: 0 1.5rem;
+}
+#main-home #about header + section > section h3 {
+  padding-top: 1.5rem;
+}
+#main-home #about header + section > section h3,
+#main-home #about header + section > section p {
+  text-align: left;
 }
 
-/*******************
-* SIGNUP/LOGIN STYLES
-******************/
-#signup {
-    width: 100%;
-
-    .signup-image {
-        width: 49%;
-        background: center/cover no-repeat url('/images/directory.jpeg');
-    }
-
-    .signup-form {
-        width: 49%;
-    }
-}
-
-#login {
-    padding: 1rem 0;
-    
-    .login-container {
-        section.card {
-            background: var(--gray-300);
-            border-radius: 12px;
-            border: none;
-            max-width: 360px;
-            width: 90%;
-
-            label.form-label {
-                font-size: 0.9rem;
-                font-weight: 500;
-                color: #495057;
-            }
-
-            input.form-control {
-                border-radius: 8px;
-                border: 1px solid #ced4da;
-                transition: all 0.3s;
-
-                &:focus {
-                    border-color: #007bff;
-                    box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
-                }
-            }
-
-            .btn {
-                margin-bottom: 10px;
-                border-radius: 50px;
-                font-size: 1rem;
-                padding: 0.6rem;
-            }
-
-            footer p {
-                font-size: 0.85rem;
-
-                a {
-                    color: #007bff;
-                    text-decoration: none;
-
-                    &:hover {
-                        text-decoration: underline;
-                    }
-                }
-            }
-        }
-    }
-}
-
-.btn-google {
-    background-color: var(--white) !important;
-    cursor: pointer;
-
-    img {
-        width: 30px;
-        height: 30px;
-        object-fit: cover;
-    }
-
-    span {
-        margin-left: 10px;
-    }
-}
-
-@media screen and (max-width: 767px) {
-    #signup {
-
-        .signup-image {
-            display: none !important;
-        }
-
-        .signup-form {
-            width: 75%;
-        }
-
-    }
-}
-
-
-/*******************
-* ERRORS STYLES
-******************/
 .error-subtitle h4 {
-    color: #253858;
-    margin-bottom: .8rem;
-    position: relative;
-    font-family: "Nunito", sans-serif;
-    font-size: 1.5rem;
+  color: #253858;
+  margin-bottom: 0.8rem;
+  position: relative;
+  font-family: "Nunito", sans-serif;
+  font-size: 1.5rem;
 }
+
 .error-info p {
-    margin-top: 0;
-    margin-bottom: 1rem;
-    display: block;
-    margin-block-start: 1em;
-    margin-block-end: 1em;
-    margin-inline-start: 0px;
-    margin-inline-end: 0px;
-    color: rgb(113, 120, 126);
-    font-family: "Nunito", sans-serif;
+  margin-top: 0;
+  margin-bottom: 1rem;
+  display: block;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  margin-inline-start: 0px;
+  margin-inline-end: 0px;
+  color: rgb(113, 120, 126);
+  font-family: "Nunito", sans-serif;
 }
+
 .btn-primary:hover {
-    color: #fff;
-    background-color: #0069d9;
-    border-color: #0062cc;
+  color: #fff;
+  background-color: #0069d9;
+  border-color: #0062cc;
 }
+
 .btn-primary {
-    color: #fff;
-    background-color: #0069d9;
-    border-color: #0062cc;
+  color: #fff;
+  background-color: #0069d9;
+  border-color: #0062cc;
 }
+
 .btn-round {
-    border-radius: 30px !important;
-    text-decoration: none;
+  border-radius: 30px !important;
+  text-decoration: none;
 }
 
 .btn {
-    font-size: 15px;
-    font-weight: 600;
-    padding: 9px 25px;
-    border-width: 2px;
-    box-shadow: 0 3px 8px 0 rgba(41,49,89,.15), inset 0 0 0 1px hsla(0,0%,100%,.1);
+  font-size: 15px;
+  font-weight: 600;
+  padding: 9px 25px;
+  border-width: 2px;
+  box-shadow: 0 3px 8px 0 rgba(41, 49, 89, 0.15), inset 0 0 0 1px hsla(0, 0%, 100%, 0.1);
 }
+
 .btn {
-    display: inline-block;
-    font-weight: 400;
-    text-align: center;
-    white-space: nowrap;
-    vertical-align: middle;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    border: 1px solid transparent;
-    padding: .375rem .75rem;
-    font-size: 1rem;
-    line-height: 1.5;
-    border-radius: .25rem;
-    transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
+  display: inline-block;
+  font-weight: 400;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  border: 1px solid transparent;
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  border-radius: 0.25rem;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
+
 .btn:not(:disabled):not(.disabled) {
-    cursor: pointer;
+  cursor: pointer;
 }
 
-/*******************
-* 404 ERROR STYLES
-******************/
+/*[404 error page]
+--------------------------*/
 .error-content {
-    padding: 0 0 70px;
+  padding: 0 0 70px;
 }
-.error-text{
-    text-align: center;
+
+.error-text {
+  text-align: center;
 }
+
 .error {
-    font-size: 180px;
-    font-weight: 100;
+  font-size: 180px;
+  font-weight: 100;
 }
+
 @keyframes bob {
-    0% {
-        top: 0;
-    }
-    50% {
-        top: 0.2em;
-    }
+  0% {
+    top: 0;
+  }
+  50% {
+    top: 0.2em;
+  }
 }
 .im-sheep {
-    display: inline-block;
-    position: relative;
-    font-size: 1em;
-    margin-bottom: 70px;
+  display: inline-block;
+  position: relative;
+  font-size: 1em;
+  margin-bottom: 70px;
 }
+
 .im-sheep * {
-    transition: transform 0.3s;
+  transition: transform 0.3s;
 }
+
 .im-sheep .top {
-    position: relative;
-    top: 0;
-    animation: bob 1s infinite;
+  position: relative;
+  top: 0;
+  animation: bob 1s infinite;
 }
+
 .im-sheep:hover .head {
-    transform: rotate(0deg);
+  transform: rotate(0deg);
 }
+
 .im-sheep:hover .head .im-eye {
-    width: 1.25em;
-    height: 1.25em;
+  width: 1.25em;
+  height: 1.25em;
 }
+
 .im-sheep:hover .head .im-eye:before {
-    right: 30%;
+  right: 30%;
 }
+
 .im-sheep:hover .top {
-    animation-play-state: paused;
+  animation-play-state: paused;
 }
+
 .im-sheep .head {
-    display: inline-block;
-    width: 5em;
-    height: 5em;
-    border-radius: 100%;
-    background: #253858;
-    vertical-align: middle;
-    position: relative;
-    top: 1em;
-    transform: rotate(30deg);
+  display: inline-block;
+  width: 5em;
+  height: 5em;
+  border-radius: 100%;
+  background: #253858;
+  vertical-align: middle;
+  position: relative;
+  top: 1em;
+  transform: rotate(30deg);
 }
+
 .im-sheep .head:before {
-    content: '';
-    display: inline-block;
-    width: 80%;
-    height: 50%;
-    background: #253858;
-    position: absolute;
-    bottom: 0;
-    right: -10%;
-    border-radius: 50% 40%;
+  content: "";
+  display: inline-block;
+  width: 80%;
+  height: 50%;
+  background: #253858;
+  position: absolute;
+  bottom: 0;
+  right: -10%;
+  border-radius: 50% 40%;
 }
+
 .im-sheep .head:hover .im-ear.one, .im-sheep .head:hover .im-ear.two {
-    transform: rotate(0deg);
+  transform: rotate(0deg);
 }
+
 .im-sheep .head .im-eye {
-    display: inline-block;
-    width: 1em;
-    height: 1em;
-    border-radius: 100%;
-    background: white;
-    position: absolute;
-    overflow: hidden;
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  border-radius: 100%;
+  background: white;
+  position: absolute;
+  overflow: hidden;
 }
+
 .im-sheep .head .im-eye:before {
-    content: '';
-    display: inline-block;
-    background: black;
-    width: 50%;
-    height: 50%;
-    border-radius: 100%;
-    position: absolute;
-    right: 10%;
-    bottom: 10%;
-    transition: all 0.3s;
+  content: "";
+  display: inline-block;
+  background: black;
+  width: 50%;
+  height: 50%;
+  border-radius: 100%;
+  position: absolute;
+  right: 10%;
+  bottom: 10%;
+  transition: all 0.3s;
 }
+
 .im-sheep .head .im-eye.one {
-    right: -2%;
-    top: 1.7em;
+  right: -2%;
+  top: 1.7em;
 }
+
 .im-sheep .head .im-eye.two {
-    right: 2.5em;
-    top: 1.7em;
+  right: 2.5em;
+  top: 1.7em;
 }
+
 .im-sheep .head .im-ear {
-    background: #253858;
-    width: 50%;
-    height: 30%;
-    border-radius: 100%;
-    position: absolute;
+  background: #253858;
+  width: 50%;
+  height: 30%;
+  border-radius: 100%;
+  position: absolute;
 }
+
 .im-sheep .head .im-ear.one {
-    left: -10%;
-    top: 5%;
-    transform: rotate(-30deg);
+  left: -10%;
+  top: 5%;
+  transform: rotate(-30deg);
 }
+
 .im-sheep .head .im-ear.two {
-    top: 2%;
-    right: -5%;
-    transform: rotate(20deg);
+  top: 2%;
+  right: -5%;
+  transform: rotate(20deg);
 }
+
 .im-sheep .body {
-    display: inline-block;
-    width: 7em;
-    height: 7em;
-    border-radius: 100%;
-    background: #0054D1;
-    position: relative;
-    vertical-align: middle;
-    margin-right: -3em;
+  display: inline-block;
+  width: 7em;
+  height: 7em;
+  border-radius: 100%;
+  background: #0054D1;
+  position: relative;
+  vertical-align: middle;
+  margin-right: -3em;
 }
+
 .im-sheep .im-legs {
-    display: inline-block;
-    position: absolute;
-    top: 80%;
-    left: 10%;
-    z-index: -1;
+  display: inline-block;
+  position: absolute;
+  top: 80%;
+  left: 10%;
+  z-index: -1;
 }
+
 .im-sheep .im-legs .im-leg {
-    display: inline-block;
-    background: #141214;
-    width: 0.5em;
-    height: 2.5em;
-    margin: 0.2em;
+  display: inline-block;
+  background: #141214;
+  width: 0.5em;
+  height: 2.5em;
+  margin: 0.2em;
 }
+
 .im-sheep::before {
-    left: 0;
-    content: '';
-    display: inline-block;
-    position: absolute;
-    top: 112%;
-    width: 100%;
-    height: 18%;
-    border-radius: 100%;
-    background: rgba(0, 0, 0, 0.2);
+  left: 0;
+  content: "";
+  display: inline-block;
+  position: absolute;
+  top: 112%;
+  width: 100%;
+  height: 18%;
+  border-radius: 100%;
+  background: rgba(0, 0, 0, 0.2);
 }
 
-/*******************
-* BOOKS STYLES
-******************/
-
-#books-home {
-    .container {
-        border-radius: 15px;
-        color: var(--gray-300);
-    }
+#books-home .container {
+  border-radius: 15px;
+  color: #dee2e6;
 }
 
-#books {
-    
-    .books-search-box {
-        color: var(--gray-300) !important;
-    }
-    
-    .book-card {
-        min-height: 100%;
-        color: var(--gray-300);
-    }
-
-    .card {
-        padding: 1rem;
-        background-color: var(--black);
-
-        img {
-            border-radius: 0.375rem;
-        }
-    }
+#books .books-search-box {
+  color: #dee2e6 !important;
+}
+#books .book-card {
+  min-height: 100%;
+  color: #dee2e6;
+}
+#books .card {
+  padding: 1rem;
+  background-color: #000000;
+}
+#books .card img {
+  border-radius: 0.375rem;
 }
 
 #book-view {
-    padding: 1rem 0;
+  padding: 1rem 0;
 }
 
-/*******************
-* AUTHORS STYLES
-******************/
-
-#authors {
-    .author-card {
-        background-color: var(--black) !important;
-    }
+#authors .author-card {
+  background-color: #000000 !important;
 }
 
 #author-view {
-    padding: 1rem 0;
-    color: var(--gray-300) !important;
+  padding: 1rem 0;
+  color: #dee2e6 !important;
 }
 
-/*******************
-* DASHBOARD STYLES
-******************/
+#signup {
+  width: 100%;
+}
+#signup .signup-image {
+  width: 49%;
+  background: center/cover no-repeat url("/images/directory.jpeg");
+}
+#signup .signup-form {
+  width: 49%;
+}
+
+#login {
+  padding: 1rem 0;
+}
+#login .login-container section.card {
+  background: #dee2e6;
+  border-radius: 12px;
+  border: none;
+  max-width: 360px;
+  width: 90%;
+}
+#login .login-container section.card label.form-label {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #495057;
+}
+#login .login-container section.card input.form-control {
+  border-radius: 8px;
+  border: 1px solid #ced4da;
+  transition: all 0.3s;
+}
+#login .login-container section.card input.form-control:focus {
+  border-color: #007bff;
+  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+}
+#login .login-container section.card .btn {
+  margin-bottom: 10px;
+  border-radius: 50px;
+  font-size: 1rem;
+  padding: 0.6rem;
+}
+#login .login-container section.card footer p {
+  font-size: 0.85rem;
+}
+#login .login-container section.card footer p a {
+  color: #007bff;
+  text-decoration: none;
+}
+#login .login-container section.card footer p a:hover {
+  text-decoration: underline;
+}
+
+.btn-google {
+  background-color: #ffffff !important;
+  cursor: pointer;
+}
+.btn-google img {
+  width: 30px;
+  height: 30px;
+  object-fit: cover;
+}
+.btn-google span {
+  margin-left: 10px;
+}
+
+@media screen and (max-width: 767px) {
+  #signup .signup-image {
+    display: none !important;
+  }
+  #signup .signup-form {
+    width: 75%;
+  }
+}
 .dashboard {
-    margin-top: 90px !important;
-
-    .stats-card {
-        border: 1px solid var(--primary);
-        border-radius: 8px;
-        padding: 1rem;
-        text-align: center;
-
-        .icon {
-            font-size: 2rem;
-            margin-bottom: 0.5rem;
-        }
-    }
-
-    th, td {
-        width: 9.09%;
-        padding: 0.5rem;
-    }
-
-    td {
-        border-bottom: 1px solid #333;
-    }
-
-    .position {
-        width: 3%;
-    }
-
-    .cover {
-        width: 10%;
-        text-align: center;
-
-        img {
-            max-width: 100%;
-            height: auto;
-            border-radius: 8px;
-        }
-    }
-
-    .title {
-        width: 20%;
-    }
-
-    td.isbn13 {
-        width: 15%;
-        font-size: 0.8rem;
-    }
-
-    .activity-feed {
-        section.card {
-            background: var(--secondary);
-            border-radius: 12px;
-            border: none;
-            color: var(--gray-300);
-        }
-
-        ul {
-            list-style: none;
-            padding: 0;
-
-            li {
-                border-bottom: 1px solid #ddd;
-                padding: 10px 0;
-
-                strong {
-                    color: #333;
-                }
-
-                small {
-                    color: #888;
-                    font-size: 0.8rem;
-                }
-            }
-        }
-    }
+  margin-top: 90px !important;
 }
-
-/*******************
-* FOOTER STYLES
-******************/
+.dashboard .stats-card {
+  border: 1px solid #0A1929;
+  border-radius: 8px;
+  padding: 1rem;
+  text-align: center;
+}
+.dashboard .stats-card .icon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+.dashboard th, .dashboard td {
+  width: 9.09%;
+  padding: 0.5rem;
+}
+.dashboard td {
+  border-bottom: 1px solid #333;
+}
+.dashboard .position {
+  width: 3%;
+}
+.dashboard .cover {
+  width: 10%;
+  text-align: center;
+}
+.dashboard .cover img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+}
+.dashboard .title {
+  width: 20%;
+}
+.dashboard td.isbn13 {
+  width: 15%;
+  font-size: 0.8rem;
+}
+.dashboard .activity-feed section.card {
+  background: #143252;
+  border-radius: 12px;
+  border: none;
+  color: #dee2e6;
+}
+.dashboard .activity-feed ul {
+  list-style: none;
+  padding: 0;
+}
+.dashboard .activity-feed ul li {
+  border-bottom: 1px solid #ddd;
+  padding: 10px 0;
+}
+.dashboard .activity-feed ul li strong {
+  color: #333;
+}
+.dashboard .activity-feed ul li small {
+  color: #888;
+  font-size: 0.8rem;
+}
 
 .footer {
-    background-color: var(--secondary) !important;
-    color: var(--gray-300) !important;
-
-    hr {
-        width: 100%;
-        height: 2px;
-    }
-
-    li {
-        margin-bottom: 0.5rem;
-    }
-
-    /* Style the copyright content */
-    .footer-bottom {
-        background-color: var(--primary);
-
-        &__copyright {
-            font-weight: 400;
-        }
-    }
-
-    a {
-        color: var(--gray-300);
-        text-decoration: none;
-
-        &:hover {
-            color: var(--gray-600);
-            text-decoration: underline;
-        }
-    }
+  background-color: #143252 !important;
+  color: #dee2e6 !important;
+}
+.footer hr {
+  width: 100%;
+  height: 2px;
+}
+.footer .company-list li {
+  margin-bottom: 0.5rem;
+}
+.footer .footer-bottom {
+  background-color: #0A1929;
+}
+.footer .footer-bottom__copyright {
+  font-weight: 400;
+}
+.footer a {
+  color: #dee2e6;
+  text-decoration: none;
+}
+.footer a:hover {
+  color: #6c757d;
+  text-decoration: underline;
 }

--- a/routes/books.js
+++ b/routes/books.js
@@ -4,6 +4,7 @@ const Book = require('../models/book')
 const Author = require('../models/author')
 const User = require('../models/user')
 const imageMimeTypes = ['image/jpeg', 'image/png', 'images/gif']
+const genres = require('../config/genres')
 const { ensureAuth, ensureGuest } = require('../middleware/auth')
 
 const booksController = require('../controller/books')
@@ -70,6 +71,7 @@ async function renderFormPage(req, res, book, form, hasError = false){
             layout: 'layouts/dashboard',
             authors: authors,
             book: book,
+            genres,
             title: 'Form Page',
             user: req.user,
             isAuth: req.isAuthenticated()

--- a/views/books/_form_fields.ejs
+++ b/views/books/_form_fields.ejs
@@ -38,6 +38,16 @@
     <input class="form-control" type="number" id="pageCount" name="pageCount" min="1" value="<%= book.pageCount %>" required />
 </div>
 
+<% const selectedGenre = book.genre || 'Other'; %>
+<div class="mb-4">
+    <label class="form-label" for="genre">Genre</label>
+    <select class="form-control" id="genre" name="genre" required>
+        <% genres.forEach(function(genre){ %>
+            <option value="<%= genre %>" <%= selectedGenre === genre ? 'selected' : '' %>><%= genre %></option>
+        <% }) %>
+    </select>
+</div>
+
 <div class="row mb-4">
     <div class="col">
         <div class="form-outline">

--- a/views/books/show.ejs
+++ b/views/books/show.ejs
@@ -8,6 +8,7 @@
             <p>Page Count: <%= book.pageCount %></p>
             <p>Description: <%= book.description %></p>
             <p>ISBN(13): <%= book.isbn %></p>
+            <p>Genre: <%= book.genre || 'Other' %></p>
             
             <div class="d-flex justify-content-around">
                 <% if(isAuth) { %>

--- a/views/dashboard/index.ejs
+++ b/views/dashboard/index.ejs
@@ -11,6 +11,36 @@
     </form>
 </section>
 
+<section class="genre-controls mt-3">
+    <form method="GET" action="/dashboard" class="row g-2 align-items-end">
+        <div class="col-sm-6 col-md-4">
+            <label class="form-label" for="genreFilter">Genre</label>
+            <select name="genre" id="genreFilter" class="form-control">
+                <option value="">All genres</option>
+                <% if (genres && genres.length) { %>
+                    <% genres.forEach(function(genre){ %>
+                        <option value="<%= genre %>" <%= selectedGenre === genre ? 'selected' : '' %>><%= genre %></option>
+                    <% }) %>
+                <% } %>
+            </select>
+        </div>
+        <div class="col-sm-6 col-md-4">
+            <label class="form-label" for="genreSort">Sort</label>
+            <select name="genreSort" id="genreSort" class="form-control">
+                <option value="">Sort by genre</option>
+                <option value="asc" <%= genreSort === 'asc' ? 'selected' : '' %>>Genre A → Z</option>
+                <option value="desc" <%= genreSort === 'desc' ? 'selected' : '' %>>Genre Z → A</option>
+            </select>
+        </div>
+        <div class="col-sm-6 col-md-2">
+            <button type="submit" class="btn btn-primary w-100">Apply</button>
+        </div>
+        <div class="col-sm-6 col-md-2">
+            <a href="/dashboard" class="btn btn-outline-secondary w-100">Reset</a>
+        </div>
+    </form>
+</section>
+
 <section class="stats row mt-4">
     <div class="col-md-4">
         <div class="stats-card">
@@ -49,6 +79,9 @@
                     </th>
                     <th alt="author" class="header field author">
                         <a href="">author</a>
+                    </th>
+                    <th alt="genre" class="header field genre">
+                        <a href="">genre</a>
                     </th>
                     <th alt="isbn13" class="header field isbn13">
                         <a href="">isbn13</a>
@@ -90,6 +123,7 @@
                     </td>
                     <td class="field title"><%= book.title %></td>
                     <td class="field author"><%= book.author.name %></td>
+                    <td class="field genre"><%= book.genre || 'Other' %></td>
                     <td class="field isbn13"><%= book.isbn %></td>
                     <td class="field numOfPages text-center"><%= book.pageCount %></td>
                     <td class="field datePub"></td>


### PR DESCRIPTION
Fixes #28 
Genre support now runs end-to-end from persistence through dashboard filtering, and signup no longer crashes on automatic login.

- Added config/genres.js (line 1) so the supported genres live in one place.

- Extended the Book schema to store validated genres (models/book.js (line 2)) and made create/update flows persist that field (controller/books.js (line 67), controller/books.js (line 94)).

- Fed genre options into the book forms (routes/books.js (line 7), views/books/_form_fields.ejs (line 41)) and surfaced the value on the detail view (views/books/show.ejs (line 11)).

- Enhanced the dashboard query to handle genre filtering/sorting and expose options (controller/dashboard.js (line 9)) alongside matching controls/column in the UI (views/dashboard/index.ejs (line 14)).

- Fixed req.logIn during signup to use the callback form, avoiding runtime errors (controller/auth.js (line 117)).